### PR TITLE
Tolerate a 3rd party plugin REST API quirk

### DIFF
--- a/classes/PublishPress/Permissions/REST.php
+++ b/classes/PublishPress/Permissions/REST.php
@@ -75,7 +75,7 @@ class REST
 			}
 
 			foreach ( $handlers as $handler ) {
-                if (!isset($handler['callback'][0]) || !is_object($handler['callback'][0])) {
+                if (!is_array($handler['callback']) || !isset($handler['callback'][0]) || !is_object($handler['callback'][0])) {
                     continue;
                 }
 


### PR DESCRIPTION
Resolve conflict with TagDiv Cloud Library plugin (Newspaper Theme) and others that use a non-standard REST handler structure.  The issue encountered is that this plugin defines $handler['callback'] as an object instead of an array of objects.