### PR TITLE
Term filtering was skipped or erroneous under some conditions

### DIFF
--- a/classes/PublishPress/Permissions/TermFilters.php
+++ b/classes/PublishPress/Permissions/TermFilters.php
@@ -134,7 +134,7 @@ class TermFilters
 
         // Prevent term reading exceptions from filtering Gutenberg term assignment checkbox visibility
         if (
-            !empty($_SERVER['HTTP_REFERER']) && strpos($_SERVER['HTTP_REFERER'], 'wp-admin/post')
+            defined('REST_REQUEST') && REST_REQUEST && !empty($_SERVER['HTTP_REFERER']) && strpos($_SERVER['HTTP_REFERER'], 'wp-admin/post') && !empty($_SERVER['HTTP_REFERER']) && strpos($_SERVER['HTTP_REFERER'], 'wp-admin/post')
             && !presspermit()->moduleActive('collaboration')
         ) {
             return true;

--- a/classes/PublishPress/Permissions/TermFiltersCount.php
+++ b/classes/PublishPress/Permissions/TermFiltersCount.php
@@ -17,7 +17,7 @@ class TermFiltersCount
 
     private function __construct()
     {
-        
+
     }
 
     private function init() {
@@ -148,7 +148,7 @@ class TermFiltersCount
 
         static $busy;
 
-        if (isset($busy)) {
+        if (!empty($busy)) {
             return $terms;
         }
 
@@ -280,7 +280,6 @@ class TermFiltersCount
         }
 
         $busy = false;
-
         return $terms;
     }
 }


### PR DESCRIPTION
Term filtering was skipped entirely for URLs linked from the Edit Post/Page screen.

When get_terms() or get_categories() was called for the second time within the same http request, function arguments child_of, hide_empty, number and pad_counts were ignored.  This occured when these functions were called within shortcode execution, and in various other custom code implementations.