### PR TITLE
Make PressPermit Notices dismissible

### DIFF
--- a/classes/PublishPress/Permissions/Admin.php
+++ b/classes/PublishPress/Permissions/Admin.php
@@ -211,10 +211,15 @@ class Admin
         return new Permissions\ErrorNotice($err_slug, $args);
     }
 
-    public function notice($notice)
+    public function notice($notice, $msg_id = '')
     {
+		$dismissals = (array) pp_get_option('dismissals');
+
+		if (isset($dismissals[$msg_id]))
+			return;
+		
         require_once(PRESSPERMIT_CLASSPATH . '/ErrorNotice.php');
         $err = new \PublishPress\Permissions\ErrorNotice();
-        $err->addNotice($notice);
+        $err->addNotice($notice, ['id' => $msg_id]);
     }
 }

--- a/classes/PublishPress/Permissions/UI/Dashboard/PluginAdmin.php
+++ b/classes/PublishPress/Permissions/UI/Dashboard/PluginAdmin.php
@@ -95,7 +95,7 @@ class PluginAdmin
                     __('Thanks for activating PressPermit. Please go to %1$sPermissions > Settings%2$s and indicate which Post Types and Taxonomies should be filtered.', 'press-permit-core'),
                     '<a href="' . $url . '">',
                     '</a>'
-                )
+                ), 'initial-activation'
             );
         }
     }
@@ -109,7 +109,7 @@ class PluginAdmin
                 __('For Pro features, replace the PressPermit plugin with Press Permit Pro. See %sPermissions > Settings > Install%s for details.', 'press-permit-core'),
                 '<a href="' . $url . '">',
                 '</a>'
-            )
+            ), 'pro-info'
         );
     }
 }


### PR DESCRIPTION
Prior to this change, former Pro users with a current or previous PP Collaborative Editing Pack installation got a non-dismissable notice until PressPermit was deactivated in favor of PressPermit Pro.