### PR TITLE
Fix fatal error with old Revisionary versions

### DIFF
--- a/press-permit-core.php
+++ b/press-permit-core.php
@@ -99,7 +99,7 @@ if (!defined('PRESSPERMIT_FILE') && !$pro_active) {
 
             // Non-critical intialization errors (may prevent integration with module or external plugin, but continue with initialization)
             if (defined('RVY_VERSION') && !defined('REVISIONARY_VERSION')) {
-                err('old_extension', ['module_title' => 'Revisionary', 'min_version' => '1.3.5']);
+                presspermit_err('old_extension', ['module_title' => 'Revisionary', 'min_version' => '1.3.5']);
             }
 
             require_once(PRESSPERMIT_CLASSPATH_COMMON . '/LibArray.php');


### PR DESCRIPTION
Fatal error occurred with Revisionary versions < 1.3.5 due to invalid function call for compatibility notice.