### PR TITLE
Term include exceptions for all post types blocked all terms

### DIFF
--- a/classes/PublishPress/Permissions/DB/Permissions.php
+++ b/classes/PublishPress/Permissions/DB/Permissions.php
@@ -554,7 +554,7 @@ class Permissions
 
             // post may be required to be IN a term set for one taxonomy, and NOT IN a term set for another taxonomy
             foreach ($mod_types as $mod) {
-                if ($tt_ids = $user->getExceptionTerms($required_operation, $mod, $post_type, $taxonomy, $args)) {
+                if ($tt_ids = $user->getExceptionTerms($required_operation, $mod, $post_type, $taxonomy, array_merge($args, ['merge_universals' => true]))) {
                     if ('include' == $mod) {
                         if ($tx_additional_ids)
                             $tt_ids = array_merge($tt_ids, $tx_additional_ids);


### PR DESCRIPTION
If a term exception was assigned for post type "all" with a modification type of 'include' ("Only these"), all terms were blocked.

This was due to the universal exception for all post types not being correctly merged into the exceptions array for the queried post type.