### PR TITLE
Pro: Revisionary 2.0 compat

### DIFF
--- a/classes/PublishPress/Permissions.php
+++ b/classes/PublishPress/Permissions.php
@@ -42,6 +42,7 @@ class Permissions
     public $doing_rest = false; 
     public $flags = [];
     public $listed_ids = [];               // $listed_ids[object_type][object_id] = true : avoid separate capability query for each listed item
+    public $meta_cap_post = false;
 
     public static function instance($args = [])
     {

--- a/classes/PublishPress/Permissions/PostFilters.php
+++ b/classes/PublishPress/Permissions/PostFilters.php
@@ -840,9 +840,11 @@ class PostFilters
         ];
 
         wp_cache_add(-1, $_post, 'posts');  // prevent querying for fake post
+        presspermit()->meta_cap_post = $_post;
         //$return = array_diff(map_meta_cap($cap_name, $user_id, $_post), [null]);  // post types which leave some basic cap properties undefined result in nulls
         $return = array_diff(map_meta_cap($cap_name, $user_id, $_post->ID), [null]);  // post types which leave some basic cap properties undefined result in nulls
         wp_cache_delete(-1, 'posts');
+        presspermit()->meta_cap_post = false;
 
         return $return;
     }


### PR DESCRIPTION
meta_cap_post property, if set, is used by Revisionary 2.0 to determine which post the last map_meta_cap filtering was performed on.