### PR TITLE
Universal Exceptions link opened wrong Edit Term screen

### DIFF
--- a/classes/PublishPress/Permissions/UI/Dashboard/TermsListing.php
+++ b/classes/PublishPress/Permissions/UI/Dashboard/TermsListing.php
@@ -136,7 +136,7 @@ class TermsListing
         ?>
         <script type="text/javascript">
             /* <![CDATA[ */
-            public function updateQueryStringParameterPP(uri, key, value) {
+            function updateQueryStringParameterPP(uri, key, value) {
                 <?php /* https://stackoverflow.com/a/6021027 */ ?>
                 var re = new RegExp("([?|&])" + key + "=.*?(&|$)", "i");
                 separator = uri.indexOf('?') !== -1 ? "&" : "?";


### PR DESCRIPTION
Category / Term listing: after clicking Universal Exceptions link, category links led to edit screen for type-specific exceptions.