### PR TITLE
Term assignment exceptions ineffective with Gutenberg

### DIFF
--- a/classes/PublishPress/Permissions/TermFilters.php
+++ b/classes/PublishPress/Permissions/TermFilters.php
@@ -167,7 +167,7 @@ class TermFilters
                     $args['required_operation'] = $rest->operation;
                 }
             } else {
-                $args['required_operation'] = 'manage';
+                $args['required_operation'] = ($rest->is_view_method) ? 'assign' : 'manage';
             }
         }
 


### PR DESCRIPTION
Exceptions to adjust term assignment access were ineffective with the Gutenberg editor.