### PR TITLE
Settings > Install: invalid Press Permit Pro 2.6.x migration caption

### DIFF
--- a/includes/SettingsTabInstall.php
+++ b/includes/SettingsTabInstall.php
@@ -163,7 +163,7 @@ class SettingsTabInstall
             );
         }
 
-        $downgrade_note = (is_array($opt_val) && count($opt_val) > 1) || get_option('ppce_version') || get_option('pps_version') || get_option('ppp_version');
+        $downgrade_note = (is_array($opt_val) && count($opt_val) > 1) || get_option('pps_version') || get_option('ppp_version');
 
         if ($msg || $downgrade_note || $key_string) :
             $section = 'key'; // --- UPDATE KEY SECTION ---


### PR DESCRIPTION
Settings > Install caption about restoring a Press Permit Pro 2.6.x installation, even if none was installed. Since version 3.0.

This occurred due to the Collaborative Publishing module being moved into Free.