### PR TITLE
Settings > Core: remove Admin Ready-Only caption for now

### DIFF
--- a/classes/PublishPress/Permissions/UI/SettingsTabCore.php
+++ b/classes/PublishPress/Permissions/UI/SettingsTabCore.php
@@ -308,11 +308,13 @@ class SettingsTabCore
                             : __('To customize editing permissions, enable the Collaborative Publishing module.', 'press-permit-core');
                     }
                     ?>
+                    <!--
                     <p style="margin-top:20px">
                     <?php
                     printf(__('%sPosts / Pages Listing:%s %s', 'press-permit-core'), '<b>', '</b>', $hint);
                     ?>
                     </p>
+                    -->
                 </td>
             </tr>
         <?php


### PR DESCRIPTION
Leave the new list_posts capability support as an undocumented feature until Capabilities is updated to provide a configuration UI.