### PR TITLE
WP 5.5: Remove old comments to avoid false alarms for .live() usage

### DIFF
--- a/common/js/presspermit.dev.js
+++ b/common/js/presspermit.dev.js
@@ -40,7 +40,6 @@ jQuery(document).ready(function ($) {
         $(this).siblings(".hide-if-js").show();
     });
 
-    //$('#userprofile_groupsdiv_pp ul.pp-agents-list li label').live('mouseenter', function() {
     $(document).on('mouseenter', '#userprofile_groupsdiv_pp ul.pp-agents-list li label', function () {
         var func = function (lbl) {
             //if ( $(lbl).is(':hover') )

--- a/common/js/role-edit.dev.js
+++ b/common/js/role-edit.dev.js
@@ -42,7 +42,6 @@ jQuery(document).ready(function ($) {
         $('#pp_add_role').remove();
     });
 
-    //$("#pp_tbl_role_selections .pp_clear").live( 'click', function(e) {
     $(document).on('click', "#pp_tbl_role_selections .pp_clear", function (e) {
         var presspermitEID = $(this).closest('tr').find('input[name="pp_presspermitEID[]"]').val();
 

--- a/modules/presspermit-collaboration/common/js/post-edit.dev.js
+++ b/modules/presspermit-collaboration/common/js/post-edit.dev.js
@@ -1,5 +1,4 @@
 jQuery(document).ready(function ($) {
-    //$('#authordiv a.pp-add-author').live( 'click', function() {
     $(document).on('click', '#authordiv a.pp-add-author', function () {
         $('#post_author_override').hide();
         $('#pp_author_search').show();
@@ -9,7 +8,6 @@ jQuery(document).ready(function ($) {
         return false;
     });
 
-    //$('#authordiv a.pp-close-add-author').live( 'click', function() {
     $(document).on('click', '#authordiv a.pp-close-add-author', function () {
         $('#pp_author_search').hide();
         $('#authordiv a.pp-close-add-author').hide();
@@ -18,7 +16,6 @@ jQuery(document).ready(function ($) {
         return false;
     });
 
-    //$('#select_agents_select-author').live( 'click', function() {
     $(document).on('click', '#select_agents_select-author', function () {
         var selected_id = $('#agent_results_select-author').val();
         if (selected_id) {
@@ -34,7 +31,6 @@ jQuery(document).ready(function ($) {
         return false;
     });
 
-    //$('#agent_results_select-author').live('jchange', function() {
     $(document).on('jchange', '#agent_results_select-author', function () {
         if ($('#agent_results_select-author option').length) {
             $('#agent_results_select-author').show();


### PR DESCRIPTION
Fixes #138