### PR TITLE
Release/3.2.4

### DIFF
--- a/press-permit-core.php
+++ b/press-permit-core.php
@@ -5,7 +5,7 @@
  * Description: Advanced yet accessible content permissions. Give users or groups type-specific roles. Enable or block access for specific posts or terms.
  * Author: PublishPress
  * Author URI:  https://publishpress.com/
- * Version:     3.2.3-beta
+ * Version:     3.2.3-beta2
  * Text Domain: press-permit-core
  * Domain Path: /languages/
  * Min WP Version: 4.9.7
@@ -98,7 +98,7 @@ if ((!defined('PRESSPERMIT_FILE') && !$pro_active) || $presspermit_loaded_by_pro
 	        return;
 	    }
 	
-	    define('PRESSPERMIT_VERSION', '3.2.3-beta');
+	    define('PRESSPERMIT_VERSION', '3.2.3-beta2');
 		
 	    if (!$presspermit_loaded_by_pro) {
 	        require_once(__DIR__ . '/includes/Core.php');

--- a/press-permit-core.php
+++ b/press-permit-core.php
@@ -5,7 +5,7 @@
  * Description: Advanced yet accessible content permissions. Give users or groups type-specific roles. Enable or block access for specific posts or terms.
  * Author: PublishPress
  * Author URI:  https://publishpress.com/
- * Version:     3.2.3
+ * Version:     3.2.4
  * Text Domain: press-permit-core
  * Domain Path: /languages/
  * Min WP Version: 4.9.7
@@ -98,7 +98,7 @@ if ((!defined('PRESSPERMIT_FILE') && !$pro_active) || $presspermit_loaded_by_pro
 	        return;
 	    }
 	
-	    define('PRESSPERMIT_VERSION', '3.2.3');
+	    define('PRESSPERMIT_VERSION', '3.2.4');
 		
 	    if (!$presspermit_loaded_by_pro) {
 	        require_once(__DIR__ . '/includes/Core.php');

--- a/readme.txt
+++ b/readme.txt
@@ -123,12 +123,13 @@ PublishPress Permissions creates and uses the following tables: pp_groups, pp_gr
 
 == Upgrade Notice ==
 
-= 3.2.2 =
+= 3.2.3 =
 Press Permit Core + PP extension users: download PublishPress Permissions Pro from publishpress.com instead of upgrading to this version.
 
 == Changelog ==
 
-= 3.2.3-beta - 10 Jul 2020 =
+= 3.2.3 - 6 Aug 2020 =
+* Fixed : Fatal error on new installations if Import module is activated
 * Fixed : REST API - When context argument is used with include argument in a GET posts query, include value is ignored
 
 = 3.2.2 - 8 Jul 2020 =

--- a/readme.txt
+++ b/readme.txt
@@ -5,7 +5,7 @@ Tags: restrict, access, permissions, cms, user, private, category, pages, privac
 Requires at least: 4.9.7
 Tested up to: 5.4
 Requires PHP: 5.6.20
-Stable tag: 3.2.3
+Stable tag: 3.2.4
 License: GPLv3
 License URI: https://www.gnu.org/licenses/gpl-3.0.html
 
@@ -123,10 +123,13 @@ PublishPress Permissions creates and uses the following tables: pp_groups, pp_gr
 
 == Upgrade Notice ==
 
-= 3.2.3 =
+= 3.2.4 =
 Press Permit Core + PP extension users: download PublishPress Permissions Pro from publishpress.com instead of upgrading to this version.
 
 == Changelog ==
+
+= 3.2.4 - 7 Aug 2020 =
+* Fixed : Page Parent could not be viewed or changed in Gutenberg editor (since 3.2.4)
 
 = 3.2.3 - 6 Aug 2020 =
 * Fixed : Fatal error on new installations if Import module is activated


### PR DESCRIPTION
Yesterday's release 3.2.3 introduced a bug: inability to view or edit page parent in the Gutenberg editor.  The fix is very simple and we need to release it to prevent confusion and frustration over the weekend.

The bug is due to a flaw in implementing the following REST API fix:

* REST API - When context argument is used with include argument in a GET posts query, include value is ignored

The fix imposed a restriction to prevent page parent filtering from being applied to other REST requests.  The restraining condition checked the wrong variable name, preventing the code from being applied to the page parent query either.  Due to other implementation factors, the result was suppression of the page parent selector.