### PR TITLE
Classic Editor plugin - block editor not detected in some configurations

### DIFF
--- a/classes/PressShack/LibWP.php
+++ b/classes/PressShack/LibWP.php
@@ -65,6 +65,9 @@ class LibWP
 					} elseif ('classic-editor' == $which) {
 						return false;
 					}
+				} else {
+                    $use_block = ('block' == get_user_meta($current_user->ID, 'wp_classic-editor-settings'));
+                    return $use_block && apply_filters('use_block_editor_for_post_type', $use_block, $post_type, PHP_INT_MAX);
 				}
 			}
 		}


### PR DESCRIPTION
Classic Editor plugin - Block editor usage was not properly detected if user selection of default editor is enabled and set to Block