### PR TITLE
Admin Categories screen: Parent "None" filtering

### DIFF
--- a/classes/PublishPress/Permissions/UI/Dashboard/TermsListing.php
+++ b/classes/PublishPress/Permissions/UI/Dashboard/TermsListing.php
@@ -177,8 +177,11 @@ class TermsListing
             $cap_name = 'manage_categories';
         }
 
-        if (!empty(presspermit()->getUser()->allcaps)) {
-            return;
+        if (!empty(presspermit()->getUser()->allcaps[$cap_name])
+        ) {
+            if (!presspermit()->getUser()->getExceptionTerms('manage', 'include', $_REQUEST['taxonomy'], $_REQUEST['taxonomy'], ['merge_universals' => true])) {
+            	return;
+            }
         }
         ?>
         <script type="text/javascript">


### PR DESCRIPTION
Term managers who are limited (through "include" exceptions) to managing a fixed set of terms had "None" category listed in Parent dropdown, even though they cannot add a top-level category.