### PR TITLE
WooCommerce: Cannot add new Product Variation

### DIFF
--- a/classes/PressShack/LibWP.php
+++ b/classes/PressShack/LibWP.php
@@ -285,6 +285,8 @@ class LibWP
             return (int)$_REQUEST['post_ID'];
         } elseif (isset($_REQUEST['post_id'])) {
             return (int)$_REQUEST['post_id'];
+        } elseif (defined('WOOCOMMERCE_VERSION') && !empty($_REQUEST['product_id'])) {
+            return (int)$_REQUEST['product_id'];
         }
     }
 


### PR DESCRIPTION
The Woo admin_ajax query for this operation passes product_id, but no post_id.

Fixes #182 