### PR TITLE
Revisions: On post-new, Revisors get failing Publish button

### DIFF
--- a/modules/presspermit-collaboration/classes/Permissions/Collab/CapabilityFilters.php
+++ b/modules/presspermit-collaboration/classes/Permissions/Collab/CapabilityFilters.php
@@ -87,7 +87,8 @@ class CapabilityFilters
                 $op = 'edit';
                 break;
             case $type_obj->cap->publish_posts:
-                $op = (presspermit()->getOption('publish_exceptions')) ? 'publish' : 'edit';
+                global $pagenow;
+                $op = (presspermit()->getOption('publish_exceptions') || (!empty($pagenow && ('post-new.php' == $pagenow)))) ? 'publish' : 'edit';
                 break;
             case $type_obj->cap->delete_posts:
                 $op = 'delete';


### PR DESCRIPTION
On new post creation, Revisors have Submit button replaced by a Publish button, which fails. The only way to submit a new post is to Save Draft first. Fixes #219