### PR TITLE
Users lacking edit_posts capability cannot embed Gutenberg blocks

### DIFF
--- a/modules/presspermit-collaboration/classes/Permissions/Collab/CapabilityFilters.php
+++ b/modules/presspermit-collaboration/classes/Permissions/Collab/CapabilityFilters.php
@@ -168,17 +168,23 @@ class CapabilityFilters
 
         global $pagenow;
 
-        if ('async-upload.php' == $pagenow) {
+        if (('async-upload.php' == $pagenow) || (in_array('edit_posts', $pp_reqd_caps, true) && presspermit()->doingEmbed())) {
             if ('upload_files' == reset($pp_reqd_caps)) {  // don't apply any exceptions for upload_files requirement on media upload
                 $return['return_caps'] = $wp_sitecaps;
-            } elseif (!empty($wp_sitecaps['upload_files'])) {
-                $_post = ($post_id) ? get_post($post_id) : false;
+            } else {
+                $require_cap = (presspermit()->doingEmbed()) ? apply_filters('presspermit_embed_capability', 'upload_files') : 'upload_files';
 
-                if (!$_post || ('attachment' == $_post->post_type)) {
-                    if (in_array('edit_posts', $pp_reqd_caps, true))
-                        $return['return_caps'] = array_merge($wp_sitecaps, ['edit_posts' => true]);
-                    elseif (in_array('edit_post', $pp_reqd_caps, true))
-                        $return['return_caps'] = array_merge($wp_sitecaps, ['edit_post' => true]);
+                if (!empty($wp_sitecaps[$require_cap])) {
+                	$_post = ($post_id) ? get_post($post_id) : false;
+
+                	if (!$_post || ('attachment' == $_post->post_type)) {
+                    	if (in_array('edit_posts', $pp_reqd_caps, true)) {
+                        	$return['return_caps'] = array_merge($wp_sitecaps, ['edit_posts' => true]);
+
+                    	} elseif (in_array('edit_post', $pp_reqd_caps, true)) {
+                        	$return['return_caps'] = array_merge($wp_sitecaps, ['edit_post' => true]);
+                        }
+                    }
                 }
             }
         }


### PR DESCRIPTION
Users who have been granted editing access for pages (or some other post type) cannot embed blocks if they lack the edit_posts capability. This is a function of the WP core post type, capability and role definitions. Let's make it more consistent by accepting the upload_files capability as an alternate criteria.

Also provide new filter 'presspermit_embed_capability' to customize this alternate capability check.

Fixes #225 