### PR TITLE
ODBC comment query: safeguard against misapplication

### DIFF
--- a/classes/PublishPress/Permissions/CommentFilters.php
+++ b/classes/PublishPress/Permissions/CommentFilters.php
@@ -56,7 +56,7 @@ class CommentFilters
                 array_merge($args, ['post_types' => $post_type, 'skip_teaser' => true, 'query_contexts' => $query_contexts])
             );
 
-        if (!empty($clauses['groupby']) && !defined('PRESSPERMIT_LEGACY_COMMENT_FILTERING')) {
+        if (!empty($clauses['groupby']) && !empty($clauses['select']) && (false !== stripos($clauses['select'], 'COUNT(')) && !defined('PRESSPERMIT_LEGACY_COMMENT_FILTERING')) {
             $clauses['orderby'] = '';
         }
 


### PR DESCRIPTION
Don't strip out the ORDER BY clause unless there is both a GROUP BY clause and a COUNT field.  Also support override by constant PRESSPERMIT_LEGACY_COMMENT_FILTERING