### PR TITLE
New Front End setting "Performance: Don't filter category / tag counts"

### DIFF
--- a/classes/PublishPress/Permissions.php
+++ b/classes/PublishPress/Permissions.php
@@ -138,6 +138,7 @@ class Permissions
             'admin_hide_uneditable_posts' => 1,
             'post_blockage_priority' => get_option('presspermit_legacy_exception_handling') ? 0 : 1,
             'media_search_results' => 1,
+            'term_counts_unfiltered' => 0,
             'advanced_options' => 0,
             'edd_key' => false,
             'supplemental_role_defs' => [], // stored by Capability Manager Enhanced

--- a/classes/PublishPress/Permissions/TermFiltersCount.php
+++ b/classes/PublishPress/Permissions/TermFiltersCount.php
@@ -212,6 +212,7 @@ class TermFiltersCount
             global $pagenow;
             if ((!is_admin() || !in_array($pagenow, ['post.php', 'post-new.php']))
                 && (!defined('PP_UNFILTERED_TERM_COUNTS') || is_admin())
+                && (in_array($pagenow, ['edit-tags.php']) || !presspermit()->getOption('term_counts_unfiltered'))
             ) {
                 if ($hide_empty || !empty($args['actual_args']['hide_empty'])) {
                     // need to tally for all terms in case some were hidden by core function due to lack of public posts
@@ -285,7 +286,7 @@ class TermFiltersCount
         if ('id=>parent' == $fields) {
 			foreach ( $terms as $term ) {
                 if (is_object($term)) {
-                $_terms[$term->term_id] = $term->parent;
+                	$_terms[$term->term_id] = $term->parent;
                 } elseif ($_term = get_term($term, reset($taxonomies))) {
                     if (!is_wp_error($_term)) {
                         $_terms[$_term->term_id] = $_term->parent;
@@ -308,8 +309,8 @@ class TermFiltersCount
                 } elseif (is_numeric($term) && count($taxonomies) == 1) {
                     if ($term = get_term($term, reset($taxonomies))) {
                         if (!is_wp_error($term)) {
-                        $_terms[] = $term->name;
-                    }
+                        	$_terms[] = $term->name;
+                    	}
                     }
                 } elseif (is_string($term)) {
                     $_terms[] = $term;
@@ -322,10 +323,10 @@ class TermFiltersCount
                 } elseif (is_numeric($term) && count($taxonomies) == 1) {
                     if ($term = get_term($term, reset($taxonomies))) {
                         if (!is_wp_error($term)) {
-                        $_terms[] = $term->slug;
-                    }
-                }
-			}
+                        	$_terms[] = $term->slug;
+                    	}
+                	}
+				}
 			}
 		} elseif ( 'id=>name' == $fields ) {
 			foreach ( $terms as $term ) {
@@ -334,10 +335,10 @@ class TermFiltersCount
                 } elseif (is_numeric($term) && count($taxonomies) == 1) {
                     if ($term = get_term($term, reset($taxonomies))) {
                         if (!is_wp_error($term)) {
-                        $_terms[ $term->term_id ] = $term->name;
-                    }
-                }
-			}
+                        	$_terms[ $term->term_id ] = $term->name;
+                    	}
+                	}
+				}
 			}
 		} elseif ( 'id=>slug' == $fields ) {
 			foreach ( $terms as $term ) {
@@ -346,7 +347,7 @@ class TermFiltersCount
                 } elseif (is_numeric($term) && count($taxonomies) == 1) {
                     if ($term = get_term($term, reset($taxonomies))) {
                         if (!is_wp_error($term)) {
-						$_terms[ $term->term_id ] = $term->slug;
+							$_terms[ $term->term_id ] = $term->slug;
                         }
                     }
                 }

--- a/classes/PublishPress/Permissions/UI/SettingsTabCore.php
+++ b/classes/PublishPress/Permissions/UI/SettingsTabCore.php
@@ -48,6 +48,7 @@ class SettingsTabCore
             'define_media_post_caps' => __('Enforce distinct edit, delete capability requirements for Media', 'press-permit-core'),
             'define_create_posts_cap' => __('Use create_posts capability', 'press-permit-core'),
             'media_search_results' => __('Search Results include Media', 'press-permit-core'),
+            'term_counts_unfiltered' => __("Performance: Don't filter category / tag counts", 'press-permit-core'),
             'strip_private_caption' => __('Suppress "Private:" Caption', 'press-permit-core'),
             'force_nav_menu_filter' => __('Filter Menu Items', 'press-permit-core'),
             'display_user_profile_groups' => __('Permission Groups on User Profile', 'press-permit-core'),
@@ -65,7 +66,7 @@ class SettingsTabCore
             'taxonomies' => ['enabled_taxonomies'],
             'post_types' => ['enabled_post_types', 'define_media_post_caps', 'define_create_posts_cap'],
             'permissions' => ['post_blockage_priority'],
-            'front_end' => ['media_search_results', 'strip_private_caption', 'force_nav_menu_filter'],
+            'front_end' => ['media_search_results', 'term_counts_unfiltered', 'strip_private_caption', 'force_nav_menu_filter'],
             'admin' => ['admin_hide_uneditable_posts'],
             'user_profile' => ['new_user_groups_ui', 'display_user_profile_groups', 'display_user_profile_roles'],
         ];
@@ -278,6 +279,8 @@ class SettingsTabCore
                 <td>
                     <?php
                     $ui->optionCheckbox('media_search_results', $tab, $section, '');
+
+                    $ui->optionCheckbox('term_counts_unfiltered', $tab, $section, '');
 
                     $hint = __('Remove the "Private:" and "Protected" prefix from Post, Page titles', 'press-permit-core');
                     $ui->optionCheckbox('strip_private_caption', $tab, $section, $hint);


### PR DESCRIPTION
The code already supports constant PP_UNFILTERED_TERM_COUNTS to disable TallyTermCounts() execution, saving some extra db queries.  This new setting exposes this performance enhancement for the general user base, now that term counts are less commonly displayed.

With the setting enabled, TallyTermCounts is executed only on wp-admin/edit-tags.php