### PR TITLE
PublishPress Revisions: Monitors group not filtered for "Publishers to Notify" UI

### DIFF
--- a/classes/PublishPress/PermissionsUser.php
+++ b/classes/PublishPress/PermissionsUser.php
@@ -328,7 +328,7 @@ class PermissionsUser extends \WP_User
         global $current_user;
 
         // @todo: review (Add New Media)
-        if (empty($current_user) || !did_action('presspermit_init')) {
+        if (empty($current_user) || !did_action('presspermit_init') || did_action('presspermit_user_reload')) {
             return $wp_blogcaps;
         }
 

--- a/modules/presspermit-collaboration/classes/Permissions/Collab/Revisionary/ContentRoles.php
+++ b/modules/presspermit-collaboration/classes/Permissions/Collab/Revisionary/ContentRoles.php
@@ -42,6 +42,7 @@ class ContentRoles extends \RevisionaryContentRoles
 
             foreach ($user_ids as $user_id) {
                 wp_set_current_user($user_id);
+                do_action('presspermit_user_reload');
 
                 $pp->clearMemcache();
                 $pp->flags['memcache_disabled'] = true;
@@ -57,6 +58,7 @@ class ContentRoles extends \RevisionaryContentRoles
 
             $pp->flags['memcache_disabled'] = false;
             wp_set_current_user($buffer_user_id);
+            do_action('presspermit_user_reload');
 
             return $ok_users;
         }


### PR DESCRIPTION
Pending Revision Monitors group members were not properly filtered for editing access prior to display as available "Publishers to Notify"

Fixes #267