### PR TITLE
Access blocked if edit_theme_options capability required by other plugin

### DIFF
--- a/modules/presspermit-collaboration/classes/Permissions/Collab/CapabilityFiltersAdmin.php
+++ b/modules/presspermit-collaboration/classes/Permissions/Collab/CapabilityFiltersAdmin.php
@@ -116,7 +116,7 @@ class CapabilityFiltersAdmin
 
         // for scoped menu management roles, satisfy edit_theme_options cap requirement
         if (('nav-menus.php' == $pagenow)
-            || (('edit_theme_options' == reset($reqd_caps)) && (PWP::doingAdminMenus() || (defined('DOING_AJAX') && DOING_AJAX)))
+            || (('edit_theme_options' == reset($reqd_caps)) && ('edit_theme_options' == $orig_cap) && (PWP::doingAdminMenus() || (defined('DOING_AJAX') && DOING_AJAX)))
         ) {
             //if ( ( 'nav-menus.php' == $pagenow ) || empty( $current_user->allcaps['edit_theme_options'] ) ) {
             if (empty($current_user->allcaps['edit_theme_options'])) {


### PR DESCRIPTION
If third party filtering adds an edit_theme_options capability requirement to some other capability requirement, Nav Menu filtering is incorrectly applied, causing improperly blocked access.