### PR TITLE
Revisions: Contributors can't edit own drafts

### DIFF
--- a/classes/PublishPress/Permissions/PostFilters.php
+++ b/classes/PublishPress/Permissions/PostFilters.php
@@ -956,6 +956,15 @@ class PostFilters
 
             $replace_caps['edit_others_drafts'] = 'read';
 
+            if (!empty($type_obj->cap->edit_others_posts)) {
+                global $current_user;
+                $list_others_cap = str_replace('edit_', 'list_', $type_obj->cap->edit_others_posts);
+
+                $replace_caps[$list_others_cap] = (!empty($current_user->allcaps[$type_obj->cap->edit_posts]))
+                ? $type_obj->cap->edit_posts
+                : str_replace('edit_', 'list_', $type_obj->cap->edit_posts);
+            }
+
             foreach ($replace_caps as $cap_name => $base_cap) {
                 $key = array_search($cap_name, $reqd_caps);
                 if (false !== $key) {

--- a/modules/presspermit-collaboration/classes/Permissions/Collab/Revisionary/Admin.php
+++ b/modules/presspermit-collaboration/classes/Permissions/Collab/Revisionary/Admin.php
@@ -205,20 +205,27 @@ class Admin
 
                 $post_type_obj = get_post_type_object($_post->post_type);
 
+                if (isset(($post_type_obj->cap->edit_others_posts)) && !in_array($post_type_obj->cap->edit_others_posts, $caps)) {
+                    return $caps;
+                }
+
                 // don't require any additional caps for sitewide Editors
                 if (!empty($current_user->allcaps[$post_type_obj->cap->edit_published_posts])) {
                     return $caps;
                 }
 
-                if (!presspermit()->doing_cap_check && empty($current_user->allcaps['edit_others_drafts']) && $post_type_obj) {
+                if (!presspermit()->doing_cap_check && $post_type_obj) {
                     if (!empty($post_type_obj->cap->edit_others_posts) && empty($current_user->allcaps[$post_type_obj->cap->edit_others_posts])) {
                         $caps[] = str_replace('edit_', 'list_', $post_type_obj->cap->edit_others_posts);
                     }
-                } else {
+                }
+
+                if (empty($current_user->allcaps['edit_others_drafts'])) {
                 	$caps[] = "edit_others_drafts";
                 }
             }
         }
+
         return $caps;
     }
 


### PR DESCRIPTION
Contributors can't edit their own drafts if PublishPress Revisions is active and has its plugin settings configured to "Editing others' revisions requires role capability"

This is not a new bug stemming from recent releases -- just newly discovered.