### PR TITLE
Support Permission Group single select (radio) on Add/Edit User

### DIFF
--- a/classes/PublishPress/Permissions/UI/Agents.php
+++ b/classes/PublishPress/Permissions/UI/Agents.php
@@ -16,10 +16,25 @@ class Agents
 
     public function agentsUI($agent_type, $all_agents, $id_suffix = '', $item_assignments = [], $args = [])
     {
-        $defaults = ['role_name' => '', 'ajax_selection' => false, 'width' => '', 'hide_checkboxes' => false];
+        $defaults = ['role_name' => '', 'ajax_selection' => false, 'width' => '', 'hide_checkboxes' => false, 'single_select' => false];
         $args = array_merge($defaults, $args);
         foreach (array_keys($defaults) as $var) {
             $$var = $args[$var];
+        }
+
+        if ($single_select) {
+            $ajax_selection = false;
+            ?>
+            <script type="text/javascript">
+                /* <![CDATA[ */
+                jQuery(document).ready(function ($) {
+                    $('ul.pp-agents-list input[type=checkbox]').click(function() {
+                        $('ul.pp-agents-list input[type=checkbox]').not(this).prop('checked', false);
+                    });
+                });
+                /* ]]> */
+            </script>
+            <?php
         }
 
         echo '<div class="pp_agents_wrapper">';

--- a/classes/PublishPress/Permissions/UI/Dashboard/Profile.php
+++ b/classes/PublishPress/Permissions/UI/Dashboard/Profile.php
@@ -110,6 +110,8 @@ class Profile
 
     public static function displayUserGroups($include_role_metagroups = false, $args = [])
     {
+        global $pagenow;
+
         $defaults = [
             'initial_hide' => false,
             'selected_only' => false,
@@ -206,12 +208,17 @@ class Profile
 
             echo "</h3>";
 
+            $single_select = ('user-new.php' == $pagenow) || (!empty($_REQUEST['pp_ajax_user']) && ('new_user_groups_ui' == $_REQUEST['pp_ajax_user']))
+            ? defined('PRESSPERMIT_ADD_USER_SINGLE_GROUP_SELECT') 
+            : defined('PRESSPERMIT_EDIT_USER_SINGLE_GROUP_SELECT');
+
             $css_id = $agent_type;
             $args = [
                 'eligible_ids' => $editable_ids,
                 'locked_ids' => $locked_ids,
                 'show_subset_caption' => false,
-                'hide_checkboxes' => $hide_checkboxes
+                'hide_checkboxes' => $hide_checkboxes,
+                'single_select' => $single_select
             ];
 
             $pp->admin()->agents()->agentsUI($agent_type, $all_groups, $css_id, $stored_groups, $args);


### PR DESCRIPTION
This UI modification is currently enabled by the following constants:

PRESSPERMIT_ADD_USER_SINGLE_GROUP_SELECT
PRESSPERMIT_EDIT_USER_SINGLE_GROUP_SELECT