### PR TITLE
Eliminate "WP" prefix from Roles label

### DIFF
--- a/classes/PublishPress/Permissions/UI/Dashboard/ItemExceptionsUI.php
+++ b/classes/PublishPress/Permissions/UI/Dashboard/ItemExceptionsUI.php
@@ -53,7 +53,7 @@ class ItemExceptionsUI
             $type_obj = ('post' == $via_item_source) ? get_post_type_object($via_item_type) : get_taxonomy($via_item_type);
         }
 
-        $agent_types['wp_role'] = (object)['labels' => (object)['name' => __('WP Roles', 'press-permit-core'), 'singular_name' => __('WP Role', 'press-permit-core')]];
+        $agent_types['wp_role'] = (object)['labels' => (object)['name' => __('Roles'), 'singular_name' => __('Role')]];
 
         $agent_types = apply_filters('presspermit_list_group_types', array_merge($agent_types, $pp->groups()->getGroupTypes([], 'object')));
 

--- a/classes/PublishPress/Permissions/UI/Groups.php
+++ b/classes/PublishPress/Permissions/UI/Groups.php
@@ -178,7 +178,7 @@ class Groups
                         $group_types = [];
 
                         if (current_user_can('pp_administer_content'))
-                            $group_types['wp_role'] = (object)['labels' => (object)['singular_name' => __('WP Role', 'press-permit-core')]];
+                            $group_types['wp_role'] = (object)['labels' => (object)['singular_name' => __('WordPress Role', 'press-permit-core')]];
 
                         $group_types['pp_group'] = (object)['labels' => (object)['singular_name' => __('Custom Group', 'press-permit-core')]];
 


### PR DESCRIPTION
Use either "Roles" or "WordPress Roles"