### PR TITLE
Classic Editor plugin: PHP warning for undefined variable current_user on some screens

### DIFF
--- a/classes/PressShack/LibWP.php
+++ b/classes/PressShack/LibWP.php
@@ -21,6 +21,8 @@ class LibWP
      */
     public static function isBlockEditorActive($post_type = '', $args = [])
     {
+        global $current_user;
+
         $defaults = ['suppress_filter' => false, 'force_refresh' => false];
         $args = array_merge($defaults, $args);
         $suppress_filter = $args['suppress_filter'];


### PR DESCRIPTION
The PHP warning occurs if with the Classic Editor plugin active if users are allowed to select their editor.

Fixes #375