### PR TITLE
PublishPress Revisions - Pending Revision Monitors group ineffective

### DIFF
--- a/modules/presspermit-collaboration/classes/Permissions/Collab/Revisionary/Admin.php
+++ b/modules/presspermit-collaboration/classes/Permissions/Collab/Revisionary/Admin.php
@@ -11,6 +11,8 @@ class Admin
             add_action('init', [$this, 'init_rvy_interface'], 2);
         }
 
+        add_action('presspermit_init_rvy_interface', [$this, 'init_rvy_interface']);
+
         add_filter('map_meta_cap', [$this, 'flt_mapMetaCap'], 3, 4);
 
         add_filter('presspermit_get_exception_items', [$this, 'flt_get_exception_items'], 10, 5);


### PR DESCRIPTION
This fix also requires Revisions 2.5.3

Fixes #379 