### PR TITLE
Revisions: Pending Revision Monitors group ineffective for new installations

### DIFF
--- a/modules/presspermit-collaboration/classes/Permissions/Collab/Revisionary/ContentRoles.php
+++ b/modules/presspermit-collaboration/classes/Permissions/Collab/Revisionary/ContentRoles.php
@@ -12,7 +12,11 @@ class ContentRoles extends \RevisionaryContentRoles
     {
         if ($group = presspermit()->groups()->getGroupByName('[' . $metagroup_name . ']')) {
             return "admin.php?page=presspermit-edit-permissions&action=edit&agent_id=$group->ID";
+        
+        } elseif ($group = presspermit()->groups()->getGroupByName($metagroup_name)) {
+            return "admin.php?page=presspermit-edit-permissions&action=edit&agent_id=$group->ID";
         }
+    
         return '';
     }
 
@@ -20,7 +24,11 @@ class ContentRoles extends \RevisionaryContentRoles
     {
         if ($group = presspermit()->groups()->getGroupByName('[' . $metagroup_name . ']')) {
             return presspermit()->groups()->getGroupMembers($group->ID, 'pp_group', 'id', ['maybe_metagroup' => true]);
+        
+        } elseif ($group = presspermit()->groups()->getGroupByName($metagroup_name)) {
+            return presspermit()->groups()->getGroupMembers($group->ID, 'pp_group', 'id', ['maybe_metagroup' => true]);
         }
+    
         return [];
     }
 


### PR DESCRIPTION
The Pending Revision Monitors group fails to control Revision submission notifications when first installation of Permissions was version 3.5 or later.

Fixes #401