### PR TITLE
HTML Forms plugin: PHP Notice on form submission / file upload

### DIFF
--- a/classes/PublishPress/PermissionsHooks.php
+++ b/classes/PublishPress/PermissionsHooks.php
@@ -336,7 +336,9 @@ class PermissionsHooks
         // content filters, loaded conditionally depending on whether the current user is a content administrator
         $this->loadContentFilters();
 
-        if (is_admin() && ('async-upload.php' != $pagenow) && !defined('XMLRPC_REQUEST') && (!defined('DOING_AJAX') || !DOING_AJAX || in_array($_REQUEST['action'], ['menu-get-metabox', 'menu-quick-search']))) {
+        if (is_admin() && ('async-upload.php' != $pagenow) && !defined('XMLRPC_REQUEST') 
+        && (!defined('DOING_AJAX') || !DOING_AJAX || (isset($_REQUEST['action']) && in_array($_REQUEST['action'], ['menu-get-metabox', 'menu-quick-search'])))
+        ) {
             // filters which are only needed for the wp-admin UI
             require_once(PRESSPERMIT_CLASSPATH . '/UI/Dashboard/DashboardFilters.php');
             new Permissions\UI\Dashboard\DashboardFilters();


### PR DESCRIPTION
Fixes #449

Work around HTML Forms plugin calling admin-ajax.php and async-upload.php with no action argument.

Replaces #446
Replaces #447

Issues cited by https://github.com/network-rail