### PR TITLE
HTML Forms plugin: PHP Notice on form submission

### DIFF
--- a/modules/presspermit-collaboration/classes/Permissions/CollabHooks.php
+++ b/modules/presspermit-collaboration/classes/Permissions/CollabHooks.php
@@ -11,6 +11,7 @@ class CollabHooks
 
         // Divi Page Builder  @todo: test whether these can be implemented with 'presspermit_unfiltered_ajax' filter in PostFilters::fltPostsClauses instead
         if (strpos($_SERVER['REQUEST_URI'], 'admin-ajax.php') 
+        && isset($_REQUEST['action'])
         && in_array(
             $_REQUEST['action'], 
             apply_filters('presspermit_unfiltered_ajax_actions',


### PR DESCRIPTION
Fixes #449

Work around HTML Forms plugin calling admin-ajax.php with no action argument.

Replaces #447

Issues cited by https://github.com/network-rail