### PR TITLE
Pro API: In current Gutenberg integration, custom default privacy requires lock

### DIFF
--- a/modules/presspermit-collaboration/classes/Permissions/Collab/UI/SettingsTabEditing.php
+++ b/modules/presspermit-collaboration/classes/Permissions/Collab/UI/SettingsTabEditing.php
@@ -183,11 +183,12 @@ class SettingsTabEditing
                                             $id = 'force_default_privacy-' . $object_type;
                                             $name = "force_default_privacy[$object_type]";
                                             $style = ($setting) ? '' : ' style="display:none"';
-                                            $checked = (!empty($force_values[$object_type])) ? 'checked="checked" ' : '';
+                                            $checked = (!empty($force_values[$object_type]) || PWP::isBlockEditorActive($object_type)) ? 'checked="checked" ' : '';
+                                            $disabled = (PWP::isBlockEditorActive($object_type)) ? " disabled=disabled " : '';
                                             ?>
                                             <input name='<?php echo $name; ?>' type='hidden' value='0'/>
                                             &nbsp;<label<?php echo $style; ?> for="<?php echo $id; ?>"><input
-                                                    type="checkbox" <?php echo $checked; ?>id="<?php echo $id; ?>"
+                                                    type="checkbox" <?php echo $checked; ?><?php echo $disabled; ?>id="<?php echo $id; ?>"
                                                     name="<?php echo $name; ?>"
                                                     value="1"/><?php if ($do_force_option) : ?>&nbsp;<?php _e('lock', 'press-permit-core'); ?><?php endif; ?>
                                         </label>

--- a/modules/presspermit-collaboration/classes/Permissions/CollabHooks.php
+++ b/modules/presspermit-collaboration/classes/Permissions/CollabHooks.php
@@ -365,7 +365,7 @@ class CollabHooks
                     }
                     */
 
-                    if ($force = presspermit()->getTypeOption('force_default_privacy', $args['post_type'])) {
+                    if ($force = presspermit()->getTypeOption('force_default_privacy', $args['post_type']) || PWP::isBlockEditorActive($args['post_type'])) {
                         // only apply if status is currently registered and PP-enabled for the post type
                         if (PWP::getPostStatuses(['name' => $default_privacy, 'post_type' => $args['post_type']])) {
                             if (!empty($args['return_meta']))


### PR DESCRIPTION
In our current implementation, configuring a post type (through Permissions > Settings > Editing) for a default custom privacy without locking that privacy results in inconsistent results (lock requirement applied in Gutenberg JS regardless of setting).  Work around this by forcing the lock setting for any post type that uses Gutenberg.

This applies to Pro installations using the Status Control module.