### PR TITLE
Update presspermit.css

### DIFF
--- a/common/css/presspermit.css
+++ b/common/css/presspermit.css
@@ -508,3 +508,8 @@ text-decoration: underline;
 .wp-core-ui .pp-agents input {
   vertical-align: text-bottom;
 }
+
+#pp-permissions-wrapper ul.subsubsub {
+float: none;
+}
+}


### PR DESCRIPTION
Permissions table header styling was broken if custom styling is applied to certain standard WP classes