### PR TITLE
Edit User screen - Permissions box styling

### DIFF
--- a/common/css/presspermit.css
+++ b/common/css/presspermit.css
@@ -512,4 +512,10 @@ text-decoration: underline;
 #pp-permissions-wrapper ul.subsubsub {
 float: none;
 }
+
+/* Edit User screen */
+div#profile-page.wrap div.pp-group-box h3:first-of-type,
+#pp_current_user_exceptions_ui
+{
+margin-top:5px !important;
 }


### PR DESCRIPTION
Edit User screen - Permissions box styling was broken if custom styling is applied to certain standard WP classes