### PR TITLE
Revisions: Contributors can't edit own draft posts in some configurations

### DIFF
--- a/classes/PublishPress/Permissions/PostFilters.php
+++ b/classes/PublishPress/Permissions/PostFilters.php
@@ -1027,6 +1027,14 @@ class PostFilters
                 }
             }
 
+            $copy_others_cap = str_replace('edit_', 'copy_', $type_obj->cap->edit_others_posts);
+
+            if (rvy_get_option('copy_posts_capability')) {
+                $replace_caps[$copy_others_cap] = str_replace('edit_', 'copy_', $type_obj->cap->edit_posts);
+            } else {
+                $replace_caps[$copy_others_cap] = 'read';
+            }
+
             foreach ($replace_caps as $cap_name => $base_cap) {
                 $key = array_search($cap_name, $reqd_caps);
                 if (false !== $key) {

--- a/modules/presspermit-collaboration/classes/Permissions/Collab/Revisions/Admin.php
+++ b/modules/presspermit-collaboration/classes/Permissions/Collab/Revisions/Admin.php
@@ -78,12 +78,14 @@ class Admin
                             $caps []= str_replace('edit_', 'list_', $post_type_obj->cap->edit_others_posts);
                         }
 
-                        $copy_cap = str_replace('edit_', 'copy_', $post_type_obj->cap->edit_others_posts);
-                        
-                        if (!empty($current_user->allcaps[$copy_cap])) {
-                            $caps[]= $copy_cap;
-                        } else {
-                            $caps []= str_replace('edit_', 'copy_', $post_type_obj->cap->edit_others_posts);
+                        if (rvy_get_option('copy_posts_capability')) {
+                            $copy_cap = str_replace('edit_', 'copy_', $post_type_obj->cap->edit_others_posts);
+                            
+                            if (!empty($current_user->allcaps[$copy_cap])) {
+                                $caps[]= $copy_cap;
+                            } else { 
+                                $caps []= str_replace('edit_', 'copy_', $post_type_obj->cap->edit_others_posts);
+                            }
                         }
                     }
                 }

--- a/modules/presspermit-collaboration/classes/Permissions/Collab/Revisions/PostFilters.php
+++ b/modules/presspermit-collaboration/classes/Permissions/Collab/Revisions/PostFilters.php
@@ -54,9 +54,24 @@ class PostFilters
     }
 
     function fltBaseCapReplacements($replace_caps, $reqd_caps, $post_type) {
+        global $current_user;
+        
         if ($type_obj = get_post_type_object($post_type)) {
             if (!empty($type_obj->cap->edit_posts)) {
                 $replace_caps['list_others_revisions'] = $type_obj->cap->edit_posts;
+                $replace_caps['edit_others_drafts'] = $type_obj->cap->edit_posts;
+
+                if (!empty($type_obj->cap->edit_others_posts)) {
+                    $copy_others_cap = str_replace('edit_', 'copy_', $type_obj->cap->edit_others_posts);
+
+                    $replace_caps[$copy_others_cap] = str_replace('edit_', 'copy_', $type_obj->cap->edit_posts);
+                }
+
+                // Don't block Contributors from editing their own drafts (copy_others requirement initially applied to map_meta_cap filter via Posts filtering)
+                if (!empty($current_user->allcaps[$type_obj->cap->edit_posts])) {
+                    $copy_cap = str_replace('edit_', 'copy_', $type_obj->cap->edit_posts);
+                    $replace_caps[$copy_cap] = $type_obj->cap->edit_posts;
+                }
             }
         }
 


### PR DESCRIPTION
If Revisions > Settings > "Prevent Revisors from editing other user's drafts" is enabled, Contributors can't edit their own draft posts.

Fixes #528