### PR TITLE
PHP 8: Warning on Users screen

### DIFF
--- a/classes/PublishPress/Permissions/UI/Dashboard/UsersListing.php
+++ b/classes/PublishPress/Permissions/UI/Dashboard/UsersListing.php
@@ -123,7 +123,7 @@ class UsersListing
         return $columns;
     }
 
-    public static function fltUsersCustomColumn($content = '', $column_name, $id)
+    public static function fltUsersCustomColumn($content, $column_name, $id)
     {
         $pp_groups = presspermit()->groups();
 


### PR DESCRIPTION
Fixes #532

Deprecated: Required parameter $column_name