### PR TITLE
Edit Group / User Permissions: roles can't be removed

### DIFF
--- a/classes/PublishPress/Permissions/UI/AgentPermissionsAjax.php
+++ b/classes/PublishPress/Permissions/UI/AgentPermissionsAjax.php
@@ -36,7 +36,9 @@ class AgentPermissionsAjax
 
         switch ($action) {
             case 'roles_remove':
-                if ($pp_ass_ids = presspermit_GET_var('pp_ass_ids')) {
+                global $current_user;
+
+                if (!$pp_ass_ids = presspermit_GET_var('pp_ass_ids')) {
                     exit;
                 }
 


### PR DESCRIPTION
Fixes #609