### PR TITLE
fix typo: presspermit_isset_REQUEST() -> presspermit_is_REQUEST()

### DIFF
--- a/classes/PublishPress/Permissions/ErrorNotice.php
+++ b/classes/PublishPress/Permissions/ErrorNotice.php
@@ -66,7 +66,7 @@ class ErrorNotice
             case 'rs_active':
                 define('PRESSPERMIT_DISABLE_QUERYFILTERS', true);
             
-                $args = (presspermit_isset_REQUEST('page') && (0 === strpos(presspermit_REQUEST_key('page'), 'presspermit-')))
+                $args = (presspermit_is_REQUEST('page') && (0 === strpos(presspermit_REQUEST_key('page'), 'presspermit-')))
                     ? ['style' => 'color:black']
                     : [];
 

--- a/classes/PublishPress/Permissions/UI/ItemsMetabox.php
+++ b/classes/PublishPress/Permissions/UI/ItemsMetabox.php
@@ -101,7 +101,7 @@ class ItemsMetabox extends \Walker_Nav_Menu
 
         $current_tab = presspermit_REQUEST_key($post_type_name . '-tab');
 
-        $pagenum = $current_tab && presspermit_isset_REQUEST('paged') ? absint(presspermit_REQUEST_var('paged')) : 1;
+        $pagenum = $current_tab && presspermit_is_REQUEST('paged') ? absint(presspermit_REQUEST_var('paged')) : 1;
         $offset = 0 < $pagenum ? $per_page * ($pagenum - 1) : 0;
 
         $args = [


### PR DESCRIPTION
there is no `presspermit_isset_REQUEST` definition
```
$ git log | head -3
commit d4530ab79e9a14733180382d1a2b5045e1347757 (HEAD -> refs/heads/master, refs/remotes/origin/master, refs/remotes/origin/HEAD)
Merge: 942c121 3004f04
Author: Kevin Behrens <43488774+agapetry@users.noreply.github.com>

$ grep -r presspermit_isset_REQUEST
classes/PublishPress/Permissions/UI/ItemsMetabox.php:        $pagenum = $current_tab && presspermit_isset_REQUEST('paged') ? absint(presspermit_REQUEST_var('paged')) : 1;
classes/PublishPress/Permissions/ErrorNotice.php:                $args = (presspermit_isset_REQUEST('page') && (0 === strpos(presspermit_REQUEST_key('page'), 'presspermit-')))
```
probably, it should be replaced with `presspermit_is_REQUEST`