### PR TITLE
Fatal error on some error notifications

### DIFF
--- a/press-permit-core.php
+++ b/press-permit-core.php
@@ -94,6 +94,8 @@ if ((!defined('PRESSPERMIT_FILE') && !$pro_active) || $presspermit_loaded_by_pro
 	    $min_php_version = '5.6.20';
 	
 	    $php_version = phpversion();
+
+	    require_once(__DIR__ . '/functions.php');
 	
 	    // Critical errors that prevent initialization
 	    if ((version_compare($min_php_version, $php_version, '>') && presspermit_err('old_php', ['min_version' => $min_php_version, 'version' => $php_version]))
@@ -151,7 +153,6 @@ if ((!defined('PRESSPERMIT_FILE') && !$pro_active) || $presspermit_loaded_by_pro
 	    require_once(PRESSPERMIT_CLASSPATH . '/API.php');
 	    
 	    require_once(__DIR__ . '/db-config.php');
-        require_once(__DIR__ . '/functions.php');
 	    require_once(__DIR__ . '/classes/PublishPress/Permissions.php');
     
 	    presspermit();


### PR DESCRIPTION
when we call `presspermit_err('rs_active')` at line 103, we run 
```
case 'rs_active':
    define('PRESSPERMIT_DISABLE_QUERYFILTERS', true);

    $args = (presspermit_is_REQUEST('page') && (0 === strpos(presspermit_REQUEST_key('page'), 'presspermit-')))
        ? ['style' => 'color:black']
        : [];
```
from classes/PublishPress/Permissions/ErrorNotice.php but `presspermit_is_REQUEST()` and `presspermit_REQUEST_key()` are not declared yet, so i propose to move `require_once(__DIR__ . '/functions.php')` above the condition to fix this issue and avoid similar issues later