### PR TITLE
Stop implicitly assigning read capability

### DIFF
--- a/classes/PublishPress/Permissions.php
+++ b/classes/PublishPress/Permissions.php
@@ -509,9 +509,8 @@ class Permissions
 						(is_multisite() && !is_user_member_of_blog()) 
 						|| (!is_admin() && !defined('PRESSPERMIT_STRICT_READ_CAP'))
 					)
-					&& empty($this->allcaps)
 				) {
-                    $user->allcaps['read'] = true;
+                    $user->allcaps[PRESSPERMIT_READ_PUBLIC_CAP] = true;
                 }
             }   
 

--- a/classes/PublishPress/Permissions/Capabilities.php
+++ b/classes/PublishPress/Permissions/Capabilities.php
@@ -125,7 +125,7 @@ class Capabilities
 			}
 			
 			// 'read' is not converted to a type-specific equivalent, so disregard it for perf. 
-			$cap_properties = array_diff($cap_properties, ['read']);
+			$cap_properties = array_diff($cap_properties, ['read', PRESSPERMIT_READ_PUBLIC_CAP]);
 
             foreach($cap_properties as $k => $cap_property) {
 				// If a cap property is set to one of the generic post type's caps, we will replace it

--- a/classes/PublishPress/Permissions/CapabilityCaster.php
+++ b/classes/PublishPress/Permissions/CapabilityCaster.php
@@ -129,6 +129,10 @@ class CapabilityCaster
         if (!$type_obj = $pp->getTypeObject($source_name, $object_type))
             return [];
 
+        if (!empty($type_obj->cap->read) && ('read' == $type_obj->cap->read)) {
+            $type_obj->cap->read = PRESSPERMIT_READ_PUBLIC_CAP;
+        } 
+
         // disregard stored Supplemental Roles for Media when Media is no longer enabled for PP filtering (otherwise Post editing caps are granted)
         if (('attachment' == $object_type)) {
             static $media_filtering_enabled;
@@ -152,7 +156,7 @@ class CapabilityCaster
         }
 
         if (!$pp->moduleActive('status-control') && strpos($role_name, 'post_status:private')
-            && isset($pattern_role_caps[$base_role_name]['read'])
+        && (isset($pattern_role_caps[$base_role_name]['read']) || isset($pattern_role_caps[$base_role_name][PRESSPERMIT_READ_PUBLIC_CAP]))
         ) {
             $pattern_role_caps[$base_role_name]['read_private_posts'] = true;
         }

--- a/classes/PublishPress/Permissions/CapabilityFilters.php
+++ b/classes/PublishPress/Permissions/CapabilityFilters.php
@@ -27,7 +27,7 @@ class CapabilityFilters
         $pp = presspermit();
         $pp->flags = array_merge($pp->flags, $this->flag_defaults);
 
-        $this->meta_caps = apply_filters('presspermit_meta_caps', ['read_post' => 'read', 'read_page' => 'read']);
+        $this->meta_caps = apply_filters('presspermit_meta_caps', ['read_post' => PRESSPERMIT_READ_PUBLIC_CAP, 'read_page' => PRESSPERMIT_READ_PUBLIC_CAP]);
 
         $this->cap_data_sources = []; // array : [$cap_name] = source_name (but default to 'post' data source if unspecified)
         $this->cap_data_sources = apply_filters('presspermit_cap_data_sources', $this->cap_data_sources);

--- a/classes/PublishPress/Permissions/PostFilters.php
+++ b/classes/PublishPress/Permissions/PostFilters.php
@@ -948,10 +948,12 @@ class PostFilters
         wp_cache_delete(-1, 'posts');
         presspermit()->meta_cap_post = false;
 
+        $return = array_map('str_replace', $return, ['read'], [PRESSPERMIT_READ_PUBLIC_CAP]);
+
         if ((1 == count($return)) && ('do_not_allow' == reset($return)) && in_array($cap_name, ['read_post', 'read_page']) && ('publish' == $status)) {
             if ($type_obj = get_post_type_object($post_type)) {
                 if (!empty($type_obj->public)) {
-                    return 'read';
+                    return PRESSPERMIT_READ_PUBLIC_CAP;
                 }
             }
         }

--- a/classes/PublishPress/Permissions/RoleDefaults.php
+++ b/classes/PublishPress/Permissions/RoleDefaults.php
@@ -11,21 +11,21 @@ class RoleDefaults
 
         switch ($role) {
             case 'subscriber':
-                return array_fill_keys(['read'], true);
+                return array_fill_keys(['read', PRESSPERMIT_READ_PUBLIC_CAP], true);
                 break;
             case 'contributor':
-                return array_fill_keys(['read', $cap->edit_posts, $cap->delete_posts], true);
+                return array_fill_keys(['read', PRESSPERMIT_READ_PUBLIC_CAP, $cap->edit_posts, $cap->delete_posts], true);
                 break;
             case 'author':
                 return array_fill_keys([
-                    'read', $cap->edit_posts, $cap->edit_published_posts, $cap->publish_posts, $cap->delete_posts,
+                    'read', PRESSPERMIT_READ_PUBLIC_CAP, $cap->edit_posts, $cap->edit_published_posts, $cap->publish_posts, $cap->delete_posts,
                     $cap->delete_published_posts, 'upload_files'
                 ], true);
 
                 break;
             case 'editor':
                 return array_fill_keys([
-                    'read', $cap->read_private_posts, $cap->edit_posts, $cap->edit_published_posts, $cap->edit_private_posts,
+                    'read', PRESSPERMIT_READ_PUBLIC_CAP, $cap->read_private_posts, $cap->edit_posts, $cap->edit_published_posts, $cap->edit_private_posts,
                     $cap->edit_others_posts, $cap->publish_posts, $cap->delete_posts, $cap->delete_others_posts,
                     $cap->delete_published_posts, $cap->delete_private_posts, 'upload_files', 'unfiltered_html',
                     'moderate_comments', 'manage_categories'
@@ -36,7 +36,7 @@ class RoleDefaults
                 if ($def_caps = apply_filters('presspermit_default_rolecaps', [], $role, $cap))
                     return $def_caps;
                 else
-                    return ($return_default) ? ['read' => true] : [];
+                    return ($return_default) ? ['read' => true, PRESSPERMIT_READ_PUBLIC_CAP => true] : [];
         }
     }
 }

--- a/classes/PublishPress/Permissions/Roles.php
+++ b/classes/PublishPress/Permissions/Roles.php
@@ -18,7 +18,7 @@ class Roles
 
     public function defineRoles()
     {
-        $this->anon_user_caps = apply_filters('presspermit_anon_user_caps', ['read']);
+        $this->anon_user_caps = apply_filters('presspermit_anon_user_caps', [PRESSPERMIT_READ_PUBLIC_CAP]);
 
         if ($direct_roles = apply_filters('presspermit_default_direct_roles', [])) {
             global $wp_roles;

--- a/classes/PublishPress/Permissions/UI/AgentRolesAjax.php
+++ b/classes/PublishPress/Permissions/UI/AgentRolesAjax.php
@@ -100,7 +100,7 @@ class AgentRolesAjax
                     }
 
                     // edit_private, delete_private caps are normally cast from pattern role
-                    if (isset($type_caps['read']) && (empty($type_caps['edit_posts']) || $direct_assignment)) {
+                    if ((isset($type_caps['read']) || isset($type_caps[PRESSPERMIT_READ_PUBLIC_CAP])) && (empty($type_caps['edit_posts']) || $direct_assignment)) {
                         $pvt_obj = get_post_status_object('private');
 
                         echo '<p class="pp-checkbox pp_select_private_status">'

--- a/classes/PublishPress/PermissionsUser.php
+++ b/classes/PublishPress/PermissionsUser.php
@@ -28,8 +28,8 @@ class PermissionsUser extends \WP_User
         parent::__construct($id, $name);
 
         // without this, logged in users have no read access to sites they're not registered for
-        if (is_multisite() && $id && !is_admin() && empty($this->allcaps)) {
-            $this->caps['read'] = true;
+        if (is_multisite() && $id && !is_admin()) {
+            $this->caps[PRESSPERMIT_READ_PUBLIC_CAP] = true;
         }
 
         $agent_type = 'pp_group';

--- a/modules/presspermit-import/classes/Permissions/Import/DB/RoleScoper.php
+++ b/modules/presspermit-import/classes/Permissions/Import/DB/RoleScoper.php
@@ -370,7 +370,7 @@ class RoleScoper extends \PublishPress\Permissions\Import\Importer
                 if (array_intersect_key($role_caps, array_fill_keys($exemption_caps, true)))
                     continue;
 
-                if (!empty($role_caps['read']) && empty($role_caps[$cap->read_private_posts]) && empty($role_caps[$cap->edit_posts])) {
+                if ((!empty($role_caps['read']) || !empty($role_caps[PRESSPERMIT_READ_PUBLIC_CAP])) && empty($role_caps[$cap->read_private_posts]) && empty($role_caps[$cap->edit_posts])) {
                     $wp_role_restrictions["{$post_type}_reader"][] = $role_name;
                 }
 

--- a/press-permit-core.php
+++ b/press-permit-core.php
@@ -132,6 +132,10 @@ if ((!defined('PRESSPERMIT_FILE') && !$pro_active) || $presspermit_loaded_by_pro
 	        define('PRESSPERMIT_LEGACY_HOOKS', false);
 	    }
 	
+        if (!defined('PRESSPERMIT_READ_PUBLIC_CAP')) {
+            define('PRESSPERMIT_READ_PUBLIC_CAP', 'read_public');
+        }
+
 	    // Non-critical intialization errors (may prevent integration with module or external plugin, but continue with initialization)
 	    if (defined('RVY_VERSION') && !defined('REVISIONARY_VERSION')) {
 	        presspermit_err('old_extension', ['module_title' => 'Revisionary', 'min_version' => '1.3.5']);


### PR DESCRIPTION
Migrate to internal use of 'read_public' capability to regulate read access to publicly published posts / pages.  By implicitly assigning this capability instead of 'read' capability, roles are not forced into dashboard access.

Fixes #649