### PR TITLE
Revert default read_public capability definition

### DIFF
--- a/classes/PublishPress/Permissions/Capabilities.php
+++ b/classes/PublishPress/Permissions/Capabilities.php
@@ -86,7 +86,7 @@ class Capabilities
             // append missing capability definitions
             foreach ($append_caps as $prop => $default) {
                 if (!isset($wp_post_types[$post_type]->cap->$prop)) {
-                    $wp_post_types[$post_type]->cap->$prop = ('read' == $prop) ? 'read' : $wp_post_types[$post_type]->cap->$default;
+                    $wp_post_types[$post_type]->cap->$prop = ('read' == $prop) ? PRESSPERMIT_READ_PUBLIC_CAP : $wp_post_types[$post_type]->cap->$default;
                 }
             }
 

--- a/classes/PublishPress/Permissions/CapabilityFilters.php
+++ b/classes/PublishPress/Permissions/CapabilityFilters.php
@@ -225,6 +225,7 @@ class CapabilityFilters
                             $base_cap = reset($base_caps);
                             switch ($base_cap) {
                                 case PRESSPERMIT_READ_PUBLIC_CAP:
+                                case 'read':
                                     $op = 'read';
                                     break;
                                 default:

--- a/press-permit-core.php
+++ b/press-permit-core.php
@@ -118,7 +118,7 @@ if ((!defined('PRESSPERMIT_FILE') && !$pro_active) || $presspermit_loaded_by_pro
 	
 	    define('PRESSPERMIT_VERSION', '3.7.6');
 		if (!defined('PRESSPERMIT_READ_PUBLIC_CAP')) {
-            define('PRESSPERMIT_READ_PUBLIC_CAP', 'read_public');
+            define('PRESSPERMIT_READ_PUBLIC_CAP', 'read');
         }
 		
 	    if (!$presspermit_loaded_by_pro) {


### PR DESCRIPTION
The read_public solution (allowing the read capability to be removed from roles to block dashboard access without making public posts unreadable) can still be activated by the following constant definition:

define('PRESSPERMIT_READ_PUBLIC_CAP', 'read_public');