### PR TITLE
Restore {$taxonomy}_children option storage

### DIFF
--- a/classes/PublishPress/Permissions/PluginUpdated.php
+++ b/classes/PublishPress/Permissions/PluginUpdated.php
@@ -50,6 +50,20 @@ class PluginUpdated
         
         	do_action('presspermit_version_updated', $prev_version);
 
+            if (version_compare($prev_version, '3.8-beta2', '<')) {
+                // Restore taxonomy_children option arrays now that an alternate filtering mechanism is in place
+                presspermit()->flags['disable_term_filtering'] = true;
+
+                if (function_exists('_get_term_hierarchy')) {
+                    foreach (presspermit()->getEnabledTaxonomies(['object_type' => false]) as $taxonomy) {
+                        delete_option("{$taxonomy}_children");
+                        _get_term_hierarchy($taxonomy);
+                    }
+                }
+
+                presspermit()->flags['disable_term_filtering'] = false;
+            } else break;
+
             if (version_compare($prev_version, '3.3.3', '<')) {
                 // Activation of invalid "Custom permissions for Authors" setting on Edit Author screen broke Authors > Authors listing and editing access
                 if ($taxs = get_option('presspermit_enabled_taxonomies')) {

--- a/classes/PublishPress/Permissions/UI/Dashboard/TermsListing.php
+++ b/classes/PublishPress/Permissions/UI/Dashboard/TermsListing.php
@@ -21,16 +21,6 @@ class TermsListing
                 add_action("manage_{$taxonomy}_custom_column", [$this, 'fltCustomColumn'], 10, 3);
 	
 	            add_action('after-' . $taxonomy . '-table', [$this, 'actShowNotes']);
-	
-	            if (is_taxonomy_hierarchical($taxonomy)) {
-	                $tx_children = get_option("{$taxonomy}_children");
-	
-	                if (!$tx_children || !is_array($tx_children) || !presspermit_empty_REQUEST('clear_db_cache') || !get_option("_ppperm_refresh_{$taxonomy}_children")) {
-	                    delete_option("{$taxonomy}_children");
-	
-	                    update_option("_ppperm_refresh_{$taxonomy}_children", true);
-	                }
-	            }
             }
         }
     }

--- a/classes/PublishPress/PermissionsHooks.php
+++ b/classes/PublishPress/PermissionsHooks.php
@@ -40,8 +40,7 @@ class PermissionsHooks
 
         // filter pre_option_category_children to disable/enable terms filtering
         foreach (presspermit()->getEnabledTaxonomies(['object_type' => false]) as $taxonomy) {
-            add_action("pre_update_option_{$taxonomy}_children", [$this, 'actClearTermChildrenCache'], 99, 3);
-            add_action("update_option_{$taxonomy}_children", [$this, 'actClearTermChildrenCache'], 99, 3);
+            add_filter("pre_option_{$taxonomy}_children", [$this, 'fltTermChildren'], 10, 3);
         }
 
         add_action('init', function() { // late execution avoids clash with autoloaders in other plugins
@@ -83,6 +82,34 @@ class PermissionsHooks
     public function filteringEnabled()
     {
         return $this->filtering_enabled;
+    }
+
+    function fltTermChildren($option_val, $option_name, $default_val) {
+        if (!empty(presspermit()->flags['disable_term_filtering'])) {
+            return $option_val;
+        }
+        
+        if ($pos = strrpos($option_name, '_children')) {
+            $taxonomy = substr($option_name, 0, $pos);
+        }
+
+        $children = array();
+        $terms    = get_terms(
+            array(
+                'taxonomy'               => $taxonomy,
+                'get'                    => 'all',
+                'orderby'                => 'id',
+                'fields'                 => 'id=>parent',
+                'update_term_meta_cache' => false,
+            )
+        );
+        foreach ( $terms as $term_id => $parent ) {
+            if ( $parent > 0 ) {
+                $children[ $parent ][] = $term_id;
+            }
+        }
+
+        return $children;
     }
 
     // if Advanced Options are not enabled, ignore stored settings
@@ -215,12 +242,16 @@ class PermissionsHooks
         $pp = presspermit();
 
         // --- version check ---
-        if ( ! $ver = get_option('presspermitpro_version') ) {
-            if (!defined('PRESSPERMIT_PRO_VERSION')) {
+        $compare_version = PRESSPERMIT_VERSION;
+
+        $ver = get_option('presspermitpro_version');
+
+        if (!$ver || !defined('PRESSPERMIT_PRO_VERSION') ) {
             	if ( ! $ver = get_option('presspermit_version') ) {
                 	$ver = get_option('pp_c_version');
                 }
-            }
+        } else {
+            $compare_version = PRESSPERMIT_PRO_VERSION;
         }
 
         if (!$ver || !is_array($ver) || empty($ver['db_version']) || version_compare(PRESSPERMIT_DB_VERSION, $ver['db_version'], '!=')) {
@@ -238,7 +269,7 @@ class PermissionsHooks
 
         if ($ver && !empty($ver['version'])) {
             // These maintenance operations only apply when a previous version of PP was installed 
-            if (version_compare(PRESSPERMIT_VERSION, $ver['version'], '!=')) {
+            if (version_compare($compare_version, $ver['version'], '!=')) {
                 require_once(PRESSPERMIT_CLASSPATH . '/PluginUpdated.php');
                 new Permissions\PluginUpdated($ver['version']);
                 update_option('presspermit_version', ['version' => PRESSPERMIT_VERSION, 'db_version' => PRESSPERMIT_DB_VERSION]);

--- a/modules/presspermit-collaboration/classes/Permissions/Collab/CapabilityFiltersAdmin.php
+++ b/modules/presspermit-collaboration/classes/Permissions/Collab/CapabilityFiltersAdmin.php
@@ -15,12 +15,6 @@ class CapabilityFiltersAdmin
         add_filter('terms_clauses', [$this, 'fltGetTermsPreserveCurrentParent'], 55, 3);
         add_filter('presspermit_posts_clauses_intercept', [$this, 'fltBypassAttachmentsFiltering'], 10, 4);
 
-        // filter pre_option_category_children, pre_update_option_category_children to disable/enable terms filtering
-        foreach (presspermit()->getEnabledTaxonomies(['object_type' => false]) as $taxonomy) {
-            add_filter("pre_option_{$taxonomy}_children", [$this, 'fltTriggerDisableTermsFilter'], 10, 2);
-            add_filter("pre_update_option_{$taxonomy}_children", [$this, 'fltTriggerDisableTermsFilter'], 10, 2);
-        }
-
         add_filter('map_meta_cap', [$this, 'fltAdjustReqdCaps'], 1, 4);
 
         add_filter('presspermit_adjust_posts_where_clause', [$this, 'fltAdjustPostsWhereClause'], 10, 4);
@@ -203,23 +197,6 @@ class CapabilityFiltersAdmin
         }
 
         return $reqd_caps;
-    }
-
-    function fltTriggerDisableTermsFilter($option_val, $option_name)
-    {  // fires on pre_option_$taxonomy filter
-        presspermit()->flags['disable_term_filtering'] = true;
-
-        $taxonomy = str_replace('_children', '', $option_name);
-        add_filter("option_{$taxonomy}_children", [$this, 'enable_terms_filter'], 10, 2);
-        add_filter("update_option_{$taxonomy}_children", [$this, 'enable_terms_filter'], 10, 2);
-
-        return $option_val;
-    }
-
-    public function enable_terms_filter($option_val, $option_name)
-    {
-        unset(presspermit()->flags['disable_term_filtering']);
-        return $option_val;
     }
 
     private function taxonomy_from_caps($caps)


### PR DESCRIPTION
The {$taxonomy}_children arrays stored to the options table normally interrupt term filtering.  Instead of forced clearance of these stored values, filter "option_{$taxonomy}_children".

Also fix version comparison logic that triggers update scripts. It was executing needlessly when running Permissions [Free] if an older version of Pro was previously installed.

Fixes #456