### PR TITLE
Add a "Remove data on uninstall" option

### DIFF
--- a/classes/PublishPress/Permissions.php
+++ b/classes/PublishPress/Permissions.php
@@ -177,6 +177,7 @@ class Permissions
             'media_search_results' => 1,
             'term_counts_unfiltered' => 0,
             'advanced_options' => 0,
+            'delete_settings_on_uninstall' => 0,
             'edd_key' => false,
             'supplemental_role_defs' => [], // stored by Capability Manager Enhanced
             'customized_roles' => [],       // stored by Capability Manager Enhanced

--- a/classes/PublishPress/Permissions/UI/SettingsTabAdvanced.php
+++ b/classes/PublishPress/Permissions/UI/SettingsTabAdvanced.php
@@ -29,7 +29,7 @@ class SettingsTabAdvanced
     public function sectionCaptions($sections)
     {
         $new = [
-            'enable' => esc_html__('Enable Advanced', 'press-permit-core'),
+            'enable' => esc_html__('Advanced Settings', 'press-permit-core'),
             'file_filtering' => esc_html__('File Filtering', 'press-permit-core'),
             'network' => esc_html__('Network-Wide Settings', 'press-permit-core'),
         ];
@@ -53,7 +53,10 @@ class SettingsTabAdvanced
 
     public function optionCaptions($captions)
     {
-        $opt = ['advanced_options' => esc_html__('Enable advanced settings', 'press-permit-core')];
+        $opt = [
+            'advanced_options' => esc_html__('Enable advanced settings', 'press-permit-core'),
+            'delete_settings_on_uninstall' => esc_html__('Delete settings on plugin deletion', 'press-permit-core'),
+        ];
 
         if ($this->enabled) {
             $opt = array_merge($opt, [
@@ -73,7 +76,7 @@ class SettingsTabAdvanced
 
     public function optionSections($sections)
     {
-        $new = ['enable' => ['advanced_options']];
+        $new = ['enable' => ['advanced_options', 'delete_settings_on_uninstall']];
 
         if ($this->enabled) {
             $new = array_merge($new, [
@@ -121,7 +124,14 @@ class SettingsTabAdvanced
                     <?php
                     $hint = '';
                     $ui->optionCheckbox('advanced_options', $tab, $section, $hint);
+
                     ?>
+                    <div>
+                    <?php
+                    $hint = esc_html__('note: Plugin settings and configuration data will be deleted, but only after the last copy of Permissions / Permissions Pro is deleted.', 'press-permit-core');
+                    $ui->optionCheckbox('delete_settings_on_uninstall', $tab, $section, $hint, '', ['hint_class' => 'pp-subtext-show']);
+                    ?>
+                    </div>
                 </td>
             </tr>
         <?php endif; // any options accessable in this section

--- a/common/css/presspermit.css
+++ b/common/css/presspermit.css
@@ -39,6 +39,7 @@
 
 .pp-subtext {
     color: #777;
+    font-style: italic;
     margin-top: 3px;
 }
 

--- a/common/css/presspermit.less
+++ b/common/css/presspermit.less
@@ -27,6 +27,7 @@
 
 .pp-subtext {
   color: #777;
+  font-style: italic;
   margin-top: 3px;
 }
 

--- a/common/css/settings.css
+++ b/common/css/settings.css
@@ -108,6 +108,10 @@ table.pp-options-table .pp-optionhint {
     display: none;
 }
 
+#pp_settings_form .pp-subtext-show {
+    display: block;
+}
+
 #pp_settings_form .pp-no-hide {
     display: revert;
     margin-top: 5px;

--- a/uninstall.php
+++ b/uninstall.php
@@ -1,0 +1,88 @@
+<?php
+if (get_option('presspermit_delete_settings_on_uninstall')) {
+    global $wpdb;
+
+    // Since stored settings are shared among all installed versions, 
+    // all copies of the plugin (both Pro and Free) need to be deleted (not just deactivated) before deleting any settings.
+    $permissions_plugin_count = 0;
+
+    if ( ! function_exists( 'get_plugins' ) ) {
+        require_once ABSPATH . 'wp-admin/includes/plugin.php';
+    }
+    
+    $plugins = get_plugins();
+    
+    foreach($plugins as $plugin) {
+        if (!empty($plugin['Title']) && in_array($plugin['Title'], ['PublishPress Permissions', 'PublishPress Permissions Pro'])) {
+            $permissions_plugin_count++;
+        }
+    }
+    
+    if ($permissions_plugin_count === 1) {
+        $orig_site_id = get_current_blog_id();
+        
+        $site_ids = (function_exists('get_sites')) ? get_sites(['fields' => 'ids']) : (array) $orig_site_id;
+        
+        foreach ($site_ids as $blog_id) {
+            switch_to_blog($blog_id);
+
+            if (!empty($wpdb->options)) {
+                @$wpdb->query("DELETE FROM $wpdb->options WHERE option_name LIKE '%presspermit%'");
+                @$wpdb->query("DELETE FROM $wpdb->options WHERE option_name LIKE 'ppperm_%'");
+            }
+
+            delete_option('ppcc_version');
+            delete_option('ppce_version');
+            delete_option('ppi_version');
+            delete_option('ppm_version');
+            delete_option('ppp_version');
+            delete_option('pps_version');
+
+            wp_load_alloptions(true);
+            
+            if (!empty($wpdb->postmeta)) {
+                @$wpdb->query(
+                    "DELETE FROM $wpdb->postmeta WHERE meta_key IN ("
+                    . "'_pp_wpml_mirrored_exceptions', '_rs_file_key', '_last_attachment_ids', '_last_category_ids', '_last_post_tag_ids', '_pp_last_parent', '_scheduled_status', '_pp_original_status', '_pp_sync_author_id', '_pp_is_autodraft', '_pp_is_auto_inserted'"
+                    . ")"
+                );
+            }
+
+            if (!empty($wpdb->pp_groups)) {
+                @$wpdb->query("DROP TABLE IF EXISTS $wpdb->pp_groups");
+            }
+
+            if (!empty($wpdb->pp_group_members)) {
+                @$wpdb->query("DROP TABLE IF EXISTS $wpdb->pp_group_members");
+            }
+
+            if (!empty($wpdb->ppc_roles)) {
+                @$wpdb->query("DROP TABLE IF EXISTS $wpdb->ppc_roles");
+            }
+
+            if (!empty($wpdb->ppc_exceptions)) {
+                @$wpdb->query("DROP TABLE IF EXISTS $wpdb->ppc_exceptions");
+            }
+
+            if (!empty($wpdb->ppc_exception_items)) {
+                @$wpdb->query("DROP TABLE IF EXISTS $wpdb->ppc_exception_items");
+            }
+
+            if (!empty($wpdb->pp_circles)) {
+                @$wpdb->query("DROP TABLE IF EXISTS $wpdb->pp_circles");
+            }
+
+            if (!empty($wpdb->pp_conditions)) {
+                @$wpdb->query("DROP TABLE IF EXISTS $wpdb->pp_conditions");
+            }
+
+            if (!empty($wpdb->ppi_runs)) {
+                @$wpdb->query("DROP TABLE IF EXISTS $wpdb->ppi_runs");
+                @$wpdb->query("DROP TABLE IF EXISTS $wpdb->ppi_imported");
+                @$wpdb->query("DROP TABLE IF EXISTS $wpdb->ppi_errors");
+            }
+        }
+
+        switch_to_blog($orig_site_id);
+    }
+}


### PR DESCRIPTION
Closes #702

Note that plugin settings and configuration data are only deleted upon deletion of the last copy of Permissions / Permissions Pro.  Plugin deletion will have no effect if another copy of the plugin remains in the plugins folder (even if it's not activated).