### PR TITLE
List others' uneditable posts by default; setting on Editing tab

### DIFF
--- a/classes/PublishPress/Permissions.php
+++ b/classes/PublishPress/Permissions.php
@@ -513,6 +513,18 @@ class Permissions
 				) {
                     $user->allcaps[PRESSPERMIT_READ_PUBLIC_CAP] = true;
                 }
+
+                if ($this->getOption('list_others_uneditable_posts')) {
+                    foreach ($this->getEnabledPostTypes() as $post_type) {
+                        if ($type_obj = get_post_type_object($post_type)) {
+                            if (isset($type_obj->cap->edit_posts) && !empty($user->allcaps[$type_obj->cap->edit_posts])
+                            && isset($type_obj->cap->edit_others_posts) && empty($user->allcaps[$type_obj->cap->edit_others_posts])) {
+                                $list_others_cap = str_replace('edit_', 'list_', $type_obj->cap->edit_others_posts);
+                                $user->allcaps[$list_others_cap] = true;
+                            }
+                        }
+                    }
+                }
             }   
 
             // merge in caps from typecast WP role assignments (and also clear false-valued allcaps entries)

--- a/classes/PublishPress/Permissions/UI/SettingsAdmin.php
+++ b/classes/PublishPress/Permissions/UI/SettingsAdmin.php
@@ -67,9 +67,6 @@ class SettingsAdmin
         case 'posts_listing_unmodified' :
         return __('Unmodified from WordPress default behavior. To enable filtering, remove constant definition PP_ADMIN_READONLY_LISTABLE.', 'press-permit-core-hints');
 
-        case 'posts_listing_editable_only' :
-        return __('Uneditable posts are hidden from wp-admin listings. To expose them, use a role editor to add desired capabilities: list_posts, list_other_pages etc.', 'press-permit-core-hints');
-
         case 'posts_listing_editable_only_collab_prompt' :
         return __('To customize editing permissions, enable the Collaborative Publishing module.', 'press-permit-core-hints');
 
@@ -115,6 +112,9 @@ class SettingsAdmin
         // Editing
         case 'collaborative-publishing' :
         return sprintf(__('Settings related to content editing permissions, provided by the %s module.', 'press-permit-core-hints'), __('Collaborative Publishing', 'press-permit-core-hints'));
+
+        case 'list_others_uneditable_posts' :
+        return __('If this setting is disabled, enable a specific role by adding capabilities: list_others_posts, list_others_pages, etc.', 'press-permit-core-hints');
 
         case 'force_taxonomy_cols' :
         return __('Display a custom column on Edit Posts screen for all related taxonomies which are enabled for Permissions filtering.', 'press-permit-core-hints');
@@ -359,7 +359,7 @@ class SettingsAdmin
 
             echo "<div class='agp-opt-checkbox " . esc_attr($option_name) . "' style='" . esc_attr($div_style) . "'>"
                 . "<label for='" . esc_attr($option_name) . "' title='" . esc_attr($title) . "'>"
-                . "<input name='" . esc_attr($option_name) . "' type='checkbox' " . esc_attr($disabled) . " style='" . esc_attr($style) . "' id='" . esc_attr($option_name) . "' value='1' " . esc_attr(checked('1', $return['val'], false)) . " /> "
+                . "<input name='" . esc_attr($option_name) . "' type='checkbox' " . esc_attr($disabled) . " style='" . esc_attr($style) . "' id='" . esc_attr($option_name) . "' value='1' " . esc_attr(checked('1', $return['val'], false)) . " autocomplete='off' /> "
                 . ( $display_label ? esc_html( $this->option_captions[$option_name] ) : '' )
 
                 . "</label>";

--- a/classes/PublishPress/Permissions/UI/SettingsTabCore.php
+++ b/classes/PublishPress/Permissions/UI/SettingsTabCore.php
@@ -334,21 +334,25 @@ class SettingsTabCore
                 <th scope="row"><?php echo esc_html($ui->section_captions[$tab][$section]); ?></th>
                 <td>
                     <?php
-                    $ui->optionCheckbox('display_branding', $tab, $section, '', '<br />');
+                    $ui->optionCheckbox('display_branding', $tab, $section);
                     
                     if (defined('PP_ADMIN_READONLY_LISTABLE') && (!$pp->getOption('admin_hide_uneditable_posts') || defined('PP_ADMIN_POSTS_NO_FILTER'))) {
                         $hint = SettingsAdmin::getStr('posts_listing_unmodified');
                     } else {
                         $hint = ($pp->moduleActive('collaboration'))
-                            ? SettingsAdmin::getStr('posts_listing_editable_only')
+                            ? ''
                             : SettingsAdmin::getStr('posts_listing_editable_only_collab_prompt');
                     }
                     ?>
-                    <div class="pp-hint">
+                    
+                    <?php if ($hint):?>
+                    <br />
+                    <div class="pp-subtext pp-subtext-show">
                     <?php
                     printf(esc_html__('%sPosts / Pages Listing:%s %s', 'press-permit-core'), '<b>', '</b>', esc_html($hint));
                     ?>
-                    </p>
+                    </div>
+                    <?php endif;?>
                 </td>
             </tr>
         <?php

--- a/modules/presspermit-collaboration/classes/Permissions/Collab/UI/SettingsTabEditing.php
+++ b/modules/presspermit-collaboration/classes/Permissions/Collab/UI/SettingsTabEditing.php
@@ -28,7 +28,8 @@ class SettingsTabEditing
     function sectionCaptions($sections)
     {
         $new = [
-            'content_management' => esc_html__('Content Management', 'press-permit-core'),
+            'post_editor' => esc_html__('Editor Options', 'press-permit-core'),
+            'content_management' => esc_html__('Posts / Pages Listing', 'press-permit-core'),
             'page_structure' => esc_html__('Page Structure', 'press-permit-core'),
             'limited_editing_elements' => esc_html__('Limited Editing Elements', 'press-permit-core'),
             'media_library' => esc_html__('Media Library', 'press-permit-core'),
@@ -59,6 +60,7 @@ class SettingsTabEditing
             'admin_nav_menu_lock_custom' => esc_html__('Lock custom menu items', 'press-permit-core'),
             'limit_user_edit_by_level' => esc_html__('Limit User Edit by Level', 'press-permit-core'),
             'default_privacy' => esc_html__('Default visibility for new posts:', 'press-permit-core'),
+            'list_others_uneditable_posts' => esc_html__('List other user\'s uneditable posts', 'press-permit-core'),
             'page_parent_order' => esc_html__('Order Page Parent dropdown by Title', 'press-permit-core'),
             'add_author_pages' => esc_html__('Bulk-Add Author Pages (on Users screen)', 'press-permit-core'),
             'publish_author_pages' => esc_html__('Publish Author Pages at bulk creation', 'press-permit-core'),
@@ -77,8 +79,9 @@ class SettingsTabEditing
         // Editing tab
         $new = [
             'page_structure' => ['lock_top_pages'],
-            'user_management' => ['limit_user_edit_by_level'],
-            'content_management' => ['default_privacy', 'force_default_privacy', 'page_parent_order', 'force_taxonomy_cols', 'add_author_pages', 'publish_author_pages'],
+            'user_management' => ['limit_user_edit_by_level', 'add_author_pages', 'publish_author_pages'],
+            'post_editor' => ['default_privacy', 'force_default_privacy', 'page_parent_order'],
+            'content_management' => ['list_others_uneditable_posts', 'force_taxonomy_cols'],
             'media_library' => ['admin_others_attached_files', 'admin_others_attached_to_readable', 'admin_others_unattached_files', 'edit_others_attached_files', 'own_attachments_always_editable'],
             'nav_menu_management' => ['admin_nav_menu_filter_items', 'admin_nav_menu_partial_editing', 'admin_nav_menu_lock_custom'],
             'post_forking' => ['fork_published_only', 'fork_require_edit_others'],
@@ -124,7 +127,7 @@ class SettingsTabEditing
         $ui = \PublishPress\Permissions\UI\SettingsAdmin::instance(); 
         $tab = 'editing';
 
-        $section = 'content_management';                        // --- CONTENT MANAGEMENT SECTION ---
+        $section = 'post_editor';                        // --- EDITOR OPTIONS SECTION ---
         if (!empty($ui->form_options[$tab][$section])) :
             ?>
             <tr>
@@ -213,15 +216,24 @@ class SettingsTabEditing
 
                     <br/>
                     <?php
-                    $hint = '';
-                    $ui->optionCheckbox('page_parent_order', $tab, $section, $hint, '<br />');
+                    $ui->optionCheckbox('page_parent_order', $tab, $section);
+                    ?>
+                </td>
+            </tr>
+        <?php endif; // any options accessable in this section
+
+        $section = 'content_management';                        // --- POSTS / PAGES LISTING SECTION ---
+        if (!empty($ui->form_options[$tab][$section])) :
+            ?>
+            <tr>
+                <th scope="row"><?php echo esc_html($ui->section_captions[$tab][$section]); ?></th>
+                <td>
+                    <?php
+                    if (!defined('PP_ADMIN_READONLY_LISTABLE') || ($pp->getOption('admin_hide_uneditable_posts') && !defined('PP_ADMIN_POSTS_NO_FILTER'))) {
+                        $ui->optionCheckbox('list_others_uneditable_posts', $tab, $section, true);
+                    }
 
                     $ui->optionCheckbox('force_taxonomy_cols', $tab, $section, true, '');
-
-                    $ui->optionCheckbox('add_author_pages', $tab, $section, true, '');
-
-                    $div_style = ($pp->getOption('add_author_pages')) ? '' : 'display:none';
-                    $ui->optionCheckbox('publish_author_pages', $tab, $section, '', '', compact('div_style'));
                     ?>
                 </td>
             </tr>
@@ -428,12 +440,20 @@ class SettingsTabEditing
                     ?>
                     </select>&nbsp;
 
-                    <p><span class='pp-subtext'>
+                    <div class='pp-subtext'>
                     <?php
                     SettingsAdmin::echoStr('limit_user_edit_by_level');
                     ?>
-                    </span>
-                    </p>
+                    </div>
+
+                    <div style="margin-top:20px">
+                    <?php
+                    $ui->optionCheckbox('add_author_pages', $tab, $section, true, '');
+
+                    $div_style = ($pp->getOption('add_author_pages')) ? '' : 'display:none';
+                    $ui->optionCheckbox('publish_author_pages', $tab, $section, '', '', compact('div_style'));
+                    ?>
+                    </div>
                 </td>
             </tr>
         <?php endif; // any options accessable in this section

--- a/modules/presspermit-collaboration/classes/Permissions/Collab/Updated.php
+++ b/modules/presspermit-collaboration/classes/Permissions/Collab/Updated.php
@@ -3,19 +3,20 @@ namespace PublishPress\Permissions\Collab;
 
 class Updated
 {
-    public function __construct($prev_version)
+    public function __construct($prev_pp_version)
     {
         // single-pass do loop to easily skip unnecessary version checks
         do {
-            if (!$prev_version) {
+            if (!$prev_pp_version) {
                 break;  // no need to run through version comparisons if no previous version
             }
 
-            if (version_compare($prev_version, '2.1.4-beta', '<')) {
-                // added pp caps for exception assignment from Post/Term edit screen by non-Administrators
-                if (!get_option('ppce_added_role_caps_21beta'))
-                    Collab::populateRoles();
+            if (version_compare($prev_pp_version, '3.8-beta4', '<')) {
+                if (null === get_option('presspermit_list_others_uneditable_posts', null)) {
+                    // If a previous version was installed, default to requiring list_others_posts capability
+                    update_option('presspermit_list_others_uneditable_posts', 0);
             }
+            } else break;
 
         } while (0); // end single-pass version check loop
     }


### PR DESCRIPTION
If this setting is enabled, implicitly add list_others_posts capability for each post type where the user has the basic editing capability.  This achieves the goal of defaulting to WP core behavior for the Posts / Pages listing.

For existing installations, store this setting false to maintain current listing behavior.

Also rearrange the Settings > Editing sections and improve hint captions for better clarity.