### PR TITLE
Classic Editor: Limited authors may be locked out of editing new page

### DIFF
--- a/classes/PublishPress/Permissions/ItemSave.php
+++ b/classes/PublishPress/Permissions/ItemSave.php
@@ -178,7 +178,7 @@ class ItemSave
         }
 
         // Inherit exceptions from new parent post/term, but only for new items or if parent is changed
-        if ((intval($set_parent) != intval($last_parent)) || $is_new_term) {
+        if ((intval($set_parent) != intval($last_parent)) || $is_new_term || $is_new) {
 
             // retain all explicitly selected exceptions
             global $wpdb;

--- a/modules/presspermit-collaboration/classes/Permissions/Collab/CapabilityFiltersAdmin.php
+++ b/modules/presspermit-collaboration/classes/Permissions/Collab/CapabilityFiltersAdmin.php
@@ -418,6 +418,23 @@ class CapabilityFiltersAdmin
         if (!current_user_can('edit_post', $post_id)) {
             if ($type_obj = get_post_type_object(get_post_field('post_type', $post_id))) {
                 if (presspermit_is_POST('save') || presspermit_is_POST('publish')) {
+                
+                    require_once(PRESSPERMIT_CLASSPATH . '/PostSave.php');
+
+                    if ($is_new = \PublishPress\Permissions\PostSave::isNewPost($post_id)) {
+                        if ($post = get_post($post_id)) {
+                            require_once(PRESSPERMIT_CLASSPATH . '/ItemSave.php');
+                            
+                            $via_item_source = 'post';
+                            $set_parent = $post->post_parent;
+                            $_args = compact('via_item_source', 'set_parent', 'is_new');
+
+                            \PublishPress\Permissions\ItemSave::inheritParentExceptions($post_id, $_args);
+
+                            return $location;
+                        }
+                    }
+                  
                     wp_die(
                         '<p>' 
                         . sprintf(

--- a/modules/presspermit-collaboration/classes/Permissions/Collab/PostSaveHierarchical.php
+++ b/modules/presspermit-collaboration/classes/Permissions/Collab/PostSaveHierarchical.php
@@ -201,6 +201,17 @@ class PostSaveHierarchical
             } else {
                 $parent_id = 0;
             }
+
+            require_once(PRESSPERMIT_CLASSPATH . '/PostSave.php');
+
+            if ($parent_id) {
+                $is_new = true;
+                require_once(PRESSPERMIT_CLASSPATH . '/ItemSave.php');
+                $via_item_source = 'post';
+                $set_parent = $parent_id;
+                $_args = compact('via_item_source', 'set_parent', 'is_new');
+                \PublishPress\Permissions\ItemSave::inheritParentExceptions($post_id, $_args);
+            }
         }
 
         $_POST['parent_id'] = $parent_id; // for subsequent post_status filter


### PR DESCRIPTION
Limited authors may be locked out of editing new page if access depends on inheriting specific permissions from a required parent page.

Fixes #804