### PR TITLE
Precaution: constants to disable new permission inheritance processes

### DIFF
--- a/modules/presspermit-collaboration/classes/Permissions/Collab/CapabilityFiltersAdmin.php
+++ b/modules/presspermit-collaboration/classes/Permissions/Collab/CapabilityFiltersAdmin.php
@@ -221,8 +221,6 @@ class CapabilityFiltersAdmin
 
         // taxonomy caps
         if ($type_caps = array_intersect($orig_reqd_caps, array_keys($caps->all_taxonomy_caps))) {
-
-
             global $tag_ID, $taxonomy;
 
             if ($taxonomy) {
@@ -419,21 +417,23 @@ class CapabilityFiltersAdmin
             if ($type_obj = get_post_type_object(get_post_field('post_type', $post_id))) {
                 if (presspermit_is_POST('save') || presspermit_is_POST('publish')) {
                 
-                    require_once(PRESSPERMIT_CLASSPATH . '/PostSave.php');
-
-                    if ($is_new = \PublishPress\Permissions\PostSave::isNewPost($post_id)) {
-                        if ($post = get_post($post_id)) {
-                            require_once(PRESSPERMIT_CLASSPATH . '/ItemSave.php');
-                            
-                            $via_item_source = 'post';
-                            $set_parent = $post->post_parent;
-                            $_args = compact('via_item_source', 'set_parent', 'is_new');
-
-                            \PublishPress\Permissions\ItemSave::inheritParentExceptions($post_id, $_args);
-
-                            return $location;
-                        }
-                    }
+                	if (!defined('PRESSPERMIT_NO_PROCESS_BEFORE_REDIRECT')) {
+	                    require_once(PRESSPERMIT_CLASSPATH . '/PostSave.php');
+	
+	                    if ($is_new = \PublishPress\Permissions\PostSave::isNewPost($post_id)) {
+	                        if ($post = get_post($post_id)) {
+	                            require_once(PRESSPERMIT_CLASSPATH . '/ItemSave.php');
+	                            
+	                            $via_item_source = 'post';
+	                            $set_parent = $post->post_parent;
+	                            $_args = compact('via_item_source', 'set_parent', 'is_new');
+	
+	                            \PublishPress\Permissions\ItemSave::inheritParentExceptions($post_id, $_args);
+	
+	                            return $location;
+	                        }
+	                    }
+                	}
                   
                     wp_die(
                         '<p>' 

--- a/modules/presspermit-collaboration/classes/Permissions/Collab/PostSaveHierarchical.php
+++ b/modules/presspermit-collaboration/classes/Permissions/Collab/PostSaveHierarchical.php
@@ -201,17 +201,19 @@ class PostSaveHierarchical
             } else {
                 $parent_id = 0;
             }
-
-            require_once(PRESSPERMIT_CLASSPATH . '/PostSave.php');
-
-            if ($parent_id) {
-                $is_new = true;
-                require_once(PRESSPERMIT_CLASSPATH . '/ItemSave.php');
-                $via_item_source = 'post';
-                $set_parent = $parent_id;
-                $_args = compact('via_item_source', 'set_parent', 'is_new');
-                \PublishPress\Permissions\ItemSave::inheritParentExceptions($post_id, $_args);
-            }
+			
+			if (!defined('PRESSPERMIT_NO_PROCESS_BEFORE_PARENT_REVERT')) {
+	            require_once(PRESSPERMIT_CLASSPATH . '/PostSave.php');
+	
+	            if ($parent_id) {
+	                $is_new = true;
+	                require_once(PRESSPERMIT_CLASSPATH . '/ItemSave.php');
+	                $via_item_source = 'post';
+	                $set_parent = $parent_id;
+	                $_args = compact('via_item_source', 'set_parent', 'is_new');
+	                \PublishPress\Permissions\ItemSave::inheritParentExceptions($post_id, $_args);
+	            }
+	    	}
         }
 
         $_POST['parent_id'] = $parent_id; // for subsequent post_status filter


### PR DESCRIPTION
Support the following constants to mitigate any unexpected effects:

define('PRESSPERMIT_NO_PROCESS_BEFORE_REDIRECT', true); define('PRESSPERMIT_NO_PROCESS_BEFORE_PARENT_REVERT', true);