### PR TITLE
Supplemental Role assigned for a specific post type grants many unrelated capabilities

### DIFF
--- a/classes/PublishPress/Permissions.php
+++ b/classes/PublishPress/Permissions.php
@@ -182,6 +182,7 @@ class Permissions
             'edd_key' => false,
             'supplemental_role_defs' => [], // stored by Capability Manager Enhanced
             'customized_roles' => [],       // stored by Capability Manager Enhanced
+            'pattern_roles_include_generic_rolecaps' => 0, // This is exposed on the Advanced tab, but intentionally excluded from the default_advanced_options array
         ];
 
         // need these keyed in separate array to force defaults if advanced options are disabled

--- a/classes/PublishPress/Permissions/CapabilityCaster.php
+++ b/classes/PublishPress/Permissions/CapabilityCaster.php
@@ -65,25 +65,48 @@ class CapabilityCaster
         $type_caps = [];
         $type_caps['post'] = array_diff_key(get_object_vars($type_obj->cap), array_fill_keys(['read_post', 'edit_post', 'delete_post'], true));
 
-        $exclude_caps = array_fill_keys(
-            apply_filters(
-                'presspermit_exclude_arbitrary_caps',
-                [
-                    'level_0', 'level_1', 'level_2', 'level_3', 'level_4', 'level_5', 'level_6', 'level_7', 'level_8', 'level_9',
-                    'level_10', 'edit_dashboard', 'add_users', 'create_users', 'edit_users', 'list_users', 'promote_users',
-                    'remove_users', 'activate_plugins', 'delete_plugins', 'edit_plugins', 'install_plugins', 'update_plugins',
-                    'delete_themes', 'edit_theme_options', 'edit_themes', 'install_themes', 'switch_themes', 'update_themes',
-                    'export', 'import', 'manage_links', 'manage_categories', 'manage_options', 'update_core', 'pp_manage_settings',
-                    'pp_administer_content', 'pp_unfiltered', 'pp_create_groups', 'pp_delete_groups', 'pp_edit_groups',
-                    'pp_manage_members'
-                ]
-            ),
-            true
-        );
+        if ($use_strict_rolecaps = !presspermit()->getOption('pattern_roles_include_generic_rolecaps')) {
+            $include_caps = array_fill_keys(
+                apply_filters(
+                    'presspermit_exclude_arbitrary_caps',
+                    [
+                        'read', 'unfiltered_html', 'upload_files', 'edit_files',
+                    ]
+                ),
+                true
+            );
+        } else {
+            $exclude_caps = array_fill_keys(
+                apply_filters(
+                    'presspermit_exclude_arbitrary_caps',
+                    [
+                        'level_0', 'level_1', 'level_2', 'level_3', 'level_4', 'level_5', 'level_6', 'level_7', 'level_8', 'level_9',
+                        'level_10', 'edit_dashboard', 'add_users', 'create_users', 'edit_users', 'list_users', 'promote_users',
+                        'remove_users', 'activate_plugins', 'delete_plugins', 'edit_plugins', 'install_plugins', 'update_plugins',
+                        'delete_themes', 'edit_theme_options', 'edit_themes', 'install_themes', 'switch_themes', 'update_themes',
+                        'export', 'import', 'manage_links', 'manage_categories', 'manage_options', 'update_core', 'pp_manage_settings',
+                        'pp_administer_content', 'pp_unfiltered', 'pp_create_groups', 'pp_delete_groups', 'pp_edit_groups',
+                        'pp_manage_members', 'manage_capabilities_dashboard',
+                        'manage_capabilities_roles',
+                        'manage_capabilities',
+                        'manage_capabilities_editor_features',
+                        'manage_capabilities_admin_features',
+                        'manage_capabilities_admin_menus',
+                        'manage_capabilities_frontend_features',
+                        'manage_capabilities_profile_features',
+                        'manage_capabilities_nav_menus',
+                        'manage_capabilities_user_testing',
+                        'manage_capabilities_backup',
+                        'manage_capabilities_settings',
+                    ]
+                ),
+                true
+            );
 
-        foreach ($pp->getOperations() as $op) {
-            $exclude_caps["pp_set_{$op}_exceptions"] = true;
-            $exclude_caps["pp_set_term_{$op}_exceptions"] = true;
+            foreach ($pp->getOperations() as $op) {
+                $exclude_caps["pp_set_{$op}_exceptions"] = true;
+                $exclude_caps["pp_set_term_{$op}_exceptions"] = true;
+            }
         }
 
         foreach (array_keys($caps) as $role_name) {
@@ -103,8 +126,15 @@ class CapabilityCaster
             }
 
             // log caps not defined for any post type or status
-            if ($misc_caps = array_diff_key($caps[$role_name], $pp->capDefs()->all_type_caps, $exclude_caps))
+            if ($use_strict_rolecaps) {
+                $misc_caps = array_intersect_key($caps[$role_name], $pp->capDefs()->all_type_caps, $include_caps);
+            } else {
+                $misc_caps = array_diff_key($caps[$role_name], $pp->capDefs()->all_type_caps, $exclude_caps);
+            }
+
+            if ($misc_caps) {
                 $this->pattern_role_arbitrary_caps[$role_name] = array_combine(array_keys($misc_caps), array_keys($misc_caps));
+            }
         }
 
         do_action('presspermit_define_pattern_caps', $caps);
@@ -210,6 +240,17 @@ class CapabilityCaster
             // note: getTypecastCaps() returns arr[pattern_cap_name] = type_cap_name
             //   but we need to return arr[type_cap_name] = true
             $add_caps = array_merge($add_caps, array_fill_keys($this->getTypecastCaps($role_name), true));
+    
+            if (!presspermit()->getOption('pattern_roles_include_generic_rolecaps')) {
+                $arr_name = explode(':', $role_name);
+                if (!empty($arr_name[3]) && ('post_status' == $arr_name[3])) {
+                    foreach (array_keys($add_caps) as $cap_name) {
+                        if (0 === strpos($cap_name, 'status_change_')) {
+                            unset($add_caps[$cap_name]);
+                        }
+                    }
+                }
+            }
         }
 
         return $add_caps;

--- a/classes/PublishPress/Permissions/PluginUpdated.php
+++ b/classes/PublishPress/Permissions/PluginUpdated.php
@@ -50,6 +50,15 @@ class PluginUpdated
         
         	do_action('presspermit_version_updated', $prev_version);
 
+            if (version_compare($prev_version, '3.11.3', '<')) {
+                if (false === get_option('presspermit_pattern_roles_include_generic_rolecaps')) {
+                    // If any type-specific supplemental roles are already stored, default to previous behavior of including many generic capabilities from Pattern Role
+                    if ($wpdb->get_row("SELECT assignment_id FROM $wpdb->ppc_roles WHERE role_name LIKE '%:%'")) {
+                        update_option('presspermit_pattern_roles_include_generic_rolecaps', 1);
+                    }
+                }
+            } else break;
+
             if (version_compare($prev_version, '3.8-beta2', '<')) {
                 // Restore taxonomy_children option arrays now that an alternate filtering mechanism is in place
                 presspermit()->flags['disable_term_filtering'] = true;

--- a/classes/PublishPress/Permissions/UI/SettingsAdmin.php
+++ b/classes/PublishPress/Permissions/UI/SettingsAdmin.php
@@ -99,6 +99,9 @@ class SettingsAdmin
         case 'display_extension_hints' :
         return  __('Display descriptive captions for additional functionality provided by missing or deactivated modules (Permissions Pro package).', 'press-permit-core-hints');
 
+        case 'pattern_roles_include_generic_rolecaps':
+        return __('Supplemental roles assigned for a specific post type will always apply "_posts" capabilities in the Pattern Role (Author, Editor, etc.) for the selected post type. This setting pertains to other capabilities in the Pattern Role. For the most consistent permissions model, capabilities unrelated to a specific type should not normally be granted by a type-specific role, but some installations may require it. Enable this setting to restore previous plugin behavior; leave it disabled for more narrowly targeted Supplemental Roles.', 'press-permit-core-hints');
+
         case 'dynamic_wp_roles' :
         return __('Detect user roles which are appended dynamically but not stored to the WP database. May be useful for sites that sync with Active Directory or other external user registration systems.', 'press-permit-core-hints');
 

--- a/classes/PublishPress/Permissions/UI/SettingsTabAdvanced.php
+++ b/classes/PublishPress/Permissions/UI/SettingsTabAdvanced.php
@@ -65,6 +65,7 @@ class SettingsTabAdvanced
                 'user_search_by_role' => esc_html__('User Search: Filter by WP role', 'press-permit-core'),
                 'display_hints' => esc_html__('Display Administrative Hints', 'press-permit-core'),
                 'display_extension_hints' => esc_html__('Display Module Hints', 'press-permit-core'),
+                'pattern_roles_include_generic_rolecaps' => esc_html__('Type-specific Supplemental Roles also provide all general capabilities in Pattern Role', 'press-permit-core'),
                 'dynamic_wp_roles' => esc_html__('Detect Dynamically Mapped WP Roles', 'press-permit-core'),
                 'non_admins_set_read_exceptions' => esc_html__('Non-Administrators can set Reading Permissions for their editable posts', 'press-permit-core'),
                 'users_bulk_groups' => esc_html__('Bulk Add / Remove Groups on Users Screen', 'press-permit-core'),
@@ -83,7 +84,7 @@ class SettingsTabAdvanced
                 'anonymous' => ['anonymous_unfiltered', 'suppress_administrator_metagroups'],
                 'permissions_admin' => ['non_admins_set_read_exceptions'],
                 'user_permissions' => ['user_permissions'],
-                'role_integration' => ['dynamic_wp_roles'],
+                'role_integration' => ['pattern_roles_include_generic_rolecaps', 'dynamic_wp_roles'],
                 'misc' => ['users_bulk_groups', 'user_search_by_role', 'display_hints', 'display_extension_hints'],
             ]);
         }
@@ -266,6 +267,10 @@ class SettingsTabAdvanced
                 <tr>
                     <th scope="row"><?php echo esc_html($ui->section_captions[$tab][$section]); ?></th>
                     <td>
+                        <?php
+                        $ui->optionCheckbox('pattern_roles_include_generic_rolecaps', $tab, $section, true, '');
+                        ?>
+
                         <div>
                         <?php printf(
                             esc_html__('To control the makeup of Supplemental Roles, see %1$sRole Usage%2$s.', 'press-permit-core'),


### PR DESCRIPTION
Fixes #939

Introduce a new Advanced setting to default to existing behavior on sites that already have supplemental roles assigned.