### PR TITLE
Post Editor: Ensure plugin compat for Page Parent dropdown

### DIFF
--- a/classes/PublishPress/Permissions/PageFilters.php
+++ b/classes/PublishPress/Permissions/PageFilters.php
@@ -26,6 +26,10 @@ class PageFilters
         //
         global $current_user, $pagenow;
 
+        if (!empty($args['no_pp_filter'])) {
+            return $results;
+        }
+
         $results = (array)$results;
 
         // buffer titles in case they were filtered previously

--- a/modules/presspermit-collaboration/classes/Permissions/Collab/PageFilters.php
+++ b/modules/presspermit-collaboration/classes/Permissions/Collab/PageFilters.php
@@ -10,6 +10,10 @@ class PageFilters
 
     function fltGetPagesArgs($args)
     {
+        if (!empty($args['no_pp_filter'])) {
+            return $args;
+        }
+
         if (!empty($args['name']) && ('parent_id' == $args['name'])) {
             global $post;
 

--- a/modules/presspermit-collaboration/classes/Permissions/Collab/RESTInit.php
+++ b/modules/presspermit-collaboration/classes/Permissions/Collab/RESTInit.php
@@ -89,7 +89,7 @@ class RESTInit
             if ($is_administrator = presspermit()->isContentAdministrator()) {
                 $pages = get_pages(
                     ['post_type' => $args['post_type'], 
-                    'suppress_filters' => 1,
+                    'no_pp_filter' => 1,
                     'post_status' => $post_statuses,
                     ]
                 );


### PR DESCRIPTION
Instead of suppressing all filters for get_pages(), suppress only Permissions filtering of get_pages()