### PR TITLE
Plugin settings: Tag count filtering disable not applied for Administrator

### DIFF
--- a/classes/PublishPress/Permissions/TermFiltersAdministrator.php
+++ b/classes/PublishPress/Permissions/TermFiltersAdministrator.php
@@ -12,7 +12,11 @@ class TermFiltersAdministrator
     {
         if (!defined('XMLRPC_REQUEST') && ('all' == $args['fields']) && empty($args['pp_no_filter'])) {
             global $pagenow;
-            if (!is_admin() || !in_array($pagenow, ['post.php', 'post-new.php'])) {
+
+            if ((!is_admin() || !in_array($pagenow, ['post.php', 'post-new.php']))
+                && (!defined('PP_UNFILTERED_TERM_COUNTS') || is_admin())
+                && (in_array($pagenow, ['edit-tags.php']) || !presspermit()->getOption('term_counts_unfiltered'))
+            ) {
                 require_once(PRESSPERMIT_CLASSPATH . '/TermQuery.php');
 
                 // pp_tallyTermCounts() is PP equivalent to WP _pad_term_counts()


### PR DESCRIPTION
Permissions > Settings > Core > Front End > "Performance: Don't filter category / tag counts" was not applied for Administrator