### PR TITLE
Legacy plugin behavior: Settings > Advanced > Limit front-end term filtering

### DIFF
--- a/classes/PublishPress/Permissions.php
+++ b/classes/PublishPress/Permissions.php
@@ -242,6 +242,7 @@ class Permissions
             'anonymous_unfiltered' => 0,
             'suppress_administrator_metagroups' => 0,
             'users_bulk_groups' => 1,
+            'limit_front_end_term_filtering' => 0,
         ];
         $this->default_advanced_options = apply_filters('presspermit_default_advanced_options', $this->default_advanced_options);
 

--- a/classes/PublishPress/Permissions/UI/SettingsAdmin.php
+++ b/classes/PublishPress/Permissions/UI/SettingsAdmin.php
@@ -84,6 +84,9 @@ class SettingsAdmin
         case 'anonymous_unfiltered' :
         return __('Disable Permissions filtering for users who are not logged in.', 'press-permit-core-hints');
 
+        case 'limit_front_end_term_filtering' :
+        return __('Legacy compatibility: front end term filters are not applied on some sites', 'press-permit-core-hints');
+
         case 'suppress_administrator_metagroups' :
         return __('If checked, pages blocked from the "All" or "Logged In" groups will still be listed to Administrators.', 'press-permit-core-hints');
 

--- a/classes/PublishPress/Permissions/UI/SettingsTabAdvanced.php
+++ b/classes/PublishPress/Permissions/UI/SettingsTabAdvanced.php
@@ -62,6 +62,7 @@ class SettingsTabAdvanced
             $opt = array_merge($opt, [
                 'anonymous_unfiltered' => sprintf(esc_html__('%1$sDisable%2$s all filtering for anonymous users', 'press-permit-core'), '', ''),
                 'suppress_administrator_metagroups' => sprintf(esc_html__('%1$sDo not apply%2$s metagroup permissions for Administrators', 'press-permit-core'), '', ''),
+                'limit_front_end_term_filtering' => sprintf(esc_html__('Limit front-end category / term filtering', 'press-permit-core')),
                 'user_search_by_role' => esc_html__('User Search: Filter by WP role', 'press-permit-core'),
                 'display_hints' => esc_html__('Display Administrative Hints', 'press-permit-core'),
                 'display_extension_hints' => esc_html__('Display Module Hints', 'press-permit-core'),
@@ -81,7 +82,7 @@ class SettingsTabAdvanced
 
         if ($this->enabled) {
             $new = array_merge($new, [
-                'anonymous' => ['anonymous_unfiltered', 'suppress_administrator_metagroups'],
+                'anonymous' => ['anonymous_unfiltered', 'suppress_administrator_metagroups', 'limit_front_end_term_filtering'],
                 'permissions_admin' => ['non_admins_set_read_exceptions'],
                 'user_permissions' => ['user_permissions'],
                 'role_integration' => ['pattern_roles_include_generic_rolecaps', 'dynamic_wp_roles'],
@@ -149,6 +150,8 @@ class SettingsTabAdvanced
                         $ui->optionCheckbox('anonymous_unfiltered', $tab, $section, true);
 
                         $ui->optionCheckbox('suppress_administrator_metagroups', $tab, $section, true);
+
+                        $ui->optionCheckbox('limit_front_end_term_filtering', $tab, $section, true);
 
                         do_action('presspermit_options_ui_insertion', $tab, $section);
                         ?>

--- a/classes/PublishPress/PermissionsHooks.php
+++ b/classes/PublishPress/PermissionsHooks.php
@@ -557,7 +557,9 @@ class PermissionsHooks
 
         if (($is_front && $front_filtering) || (!$is_unfiltered && (!defined('DOING_AUTOSAVE') || !DOING_AUTOSAVE))) {
             // Work around unexplained issue with access to static methods of LibWP class failing if called before init action
-            if (did_action('init') || defined('PRESSPERMIT_TERM_FILTERS_LEGACY_LOAD')) {
+            if ((did_action('init') || defined('PRESSPERMIT_TERM_FILTERS_LEGACY_LOAD')) 
+            && !presspermit()->getOption('limit_front_end_term_filtering')
+            ) {
                 require_once(PRESSPERMIT_CLASSPATH . '/TermFilters.php');
                 new Permissions\TermFilters();
             } else {


### PR DESCRIPTION
Option to restore previous behavior by suppressing front end term filtering under some conditions