### PR TITLE
ACF: Type-specific capabilities not enforced for CPT unless explicitly configured in ACF settings

### DIFF
--- a/classes/PublishPress/Permissions.php
+++ b/classes/PublishPress/Permissions.php
@@ -109,8 +109,8 @@ class Permissions
         return !empty($this->inserted_posts[$post_id]);
     }
 
-    public function capDefs() {
-        if (!isset($this->cap_defs)) {
+    public function capDefs($args = []) {
+        if (!isset($this->cap_defs) || !empty($args['force'])) {
             require_once(PRESSPERMIT_CLASSPATH . '/Capabilities.php');
             $this->cap_defs = new Permissions\Capabilities();
         }

--- a/classes/PublishPress/PermissionsHooks.php
+++ b/classes/PublishPress/PermissionsHooks.php
@@ -99,6 +99,10 @@ class PermissionsHooks
 
     public function loadFilters()
     {
+        if (!defined('PRESSPERMIT_NO_EARLY_CAPS_INIT')) {
+            add_action('init', function() {presspermit()->capDefs(['force' => true]);}, 5);
+        }
+
         add_action('set_current_user', [$this, 'actSetCurrentUser'], 99);
         add_action('init', [$this, 'actInit'], 50);
         add_action('wp_loaded', [presspermit(), 'refreshUserAllcaps'], 18);   // account for any type / condition caps adding by late registration


### PR DESCRIPTION
Fixes #1118