### PR TITLE
On translated WP 6.7 sites, pre-init translations cause an error

### DIFF
--- a/modules/presspermit-collaboration/presspermit-collaboration.php
+++ b/modules/presspermit-collaboration/presspermit-collaboration.php
@@ -45,11 +45,7 @@ if (!defined('PRESSPERMIT_COLLAB_FILE')) {
 
             $ext_version = PRESSPERMIT_VERSION;
 
-            if (is_admin()) {
-                $title = esc_html__('Collaborative Publishing', 'press-permit-core');
-            } else {
-                $title = 'Collaborative Publishing';
-            }
+            $title = 'Collaborative Publishing'; // @todo: review removing this, as it is separately set with translation downstream
 
             if (presspermit()->registerModule(
                 'collaboration', $title, dirname(plugin_basename(__FILE__)), $ext_version, ['min_pp_version' => '2.7-beta']

--- a/modules/presspermit-import/presspermit-import.php
+++ b/modules/presspermit-import/presspermit-import.php
@@ -45,7 +45,7 @@ if (!defined('PRESSPERMIT_IMPORT_FILE')) {
 
             $ext_version = PRESSPERMIT_VERSION;
 
-            $title = esc_html__('Import', 'press-permit-core');
+            $title = 'Import'; // @todo: review removing this, as it is separately set with translation downstream
 
             if (presspermit()->registerModule(
                 'import', $title, dirname(plugin_basename(__FILE__)), $ext_version, ['min_pp_version' => '2.7-beta']


### PR DESCRIPTION
These were redundant / ineffective translation calls, as the module title is set with translation in another function after the init action.