### PR TITLE
Plugin Settings section "Admin Back End" is empty with free plugin

### DIFF
--- a/classes/PublishPress/Permissions/UI/SettingsTabAdvanced.php
+++ b/classes/PublishPress/Permissions/UI/SettingsTabAdvanced.php
@@ -225,7 +225,24 @@ class SettingsTabAdvanced
                         $ui->optionCheckbox('limit_front_end_term_filtering', $tab, $section, true);
 
                         do_action('presspermit_options_ui_insertion', $tab, $section);
+
+                        if (defined('PP_ADMIN_READONLY_LISTABLE') && (!$pp->getOption('admin_hide_uneditable_posts') || defined('PP_ADMIN_POSTS_NO_FILTER'))) {
+                            $hint = SettingsAdmin::getStr('posts_listing_unmodified');
+                        } else {
+                            $hint = ($pp->moduleActive('collaboration'))
+                                ? ''
+                                : SettingsAdmin::getStr('posts_listing_editable_only_collab_prompt');
+                        }
                         ?>
+                        
+                        <?php if ($hint):?>
+                        <br />
+                        <div class="pp-subtext pp-subtext-show">
+                        <?php
+                        printf(esc_html__('%sPosts / Pages Listing:%s %s', 'press-permit-core'), '<b>', '</b>', esc_html($hint));
+                        ?>
+                        </div>
+                        <?php endif;?>
                     </td>
                 </tr>
             <?php endif; // any options accessable in this section

--- a/classes/PublishPress/Permissions/UI/SettingsTabCore.php
+++ b/classes/PublishPress/Permissions/UI/SettingsTabCore.php
@@ -54,7 +54,7 @@ class SettingsTabCore
         $new = [
             'taxonomies' => ['enabled_taxonomies', 'create_tag_require_edit_cap'],
             'post_types' => ['enabled_post_types', 'define_media_post_caps', 'define_create_posts_cap'],
-            'admin' => ['admin_hide_uneditable_posts'],
+            'admin' => [],
         ];
 
         $key = 'core';
@@ -333,24 +333,7 @@ class SettingsTabCore
                 <td>
                     <?php
                     $ui->optionCheckbox('display_branding', $tab, $section);
-
-                    if (defined('PP_ADMIN_READONLY_LISTABLE') && (!$pp->getOption('admin_hide_uneditable_posts') || defined('PP_ADMIN_POSTS_NO_FILTER'))) {
-                        $hint = SettingsAdmin::getStr('posts_listing_unmodified');
-                    } else {
-                        $hint = ($pp->moduleActive('collaboration'))
-                            ? ''
-                            : SettingsAdmin::getStr('posts_listing_editable_only_collab_prompt');
-                    }
                     ?>
-
-                    <?php if ($hint): ?>
-                        <br />
-                        <div class="pp-subtext pp-subtext-show">
-                            <?php
-                            printf(esc_html__('%sPosts / Pages Listing:%s %s', 'press-permit-core'), '<b>', '</b>', esc_html($hint));
-                            ?>
-                        </div>
-                    <?php endif; ?>
                 </td>
             </tr>
 <?php


### PR DESCRIPTION
Under some site configurations, this section previously displayed contextual guidance regarding filtering of the Posts / Pages listing. This output has been moved to the Content Filtering section of the Advanced tab.

Fixes #1294