### PR TITLE
Fatal error if other code filters pre_tax_input incorrectly

### DIFF
--- a/modules/presspermit-collaboration/classes/Permissions/Collab/PostTermsSave.php
+++ b/modules/presspermit-collaboration/classes/Permissions/Collab/PostTermsSave.php
@@ -197,8 +197,14 @@ class PostTermsSave
 
     public static function fltTaxInput($tax_input)
     {
+        if (!is_array($tax_input)) {
+            return $tax_input;
+        }
+
         foreach ((array)$tax_input as $taxonomy => $terms) {
-            $tax_input[$taxonomy] = self::fltTermsInput($terms, $taxonomy);
+            if (is_string($taxonomy) && !is_numeric($taxonomy)) {
+            	$tax_input[$taxonomy] = self::fltTermsInput($terms, $taxonomy);
+            }
         }
 
         return $tax_input;


### PR DESCRIPTION
The pre_tax_input filter passes a 2D array with taxonomy as the first key. However, other code may incorrectly filter it upstream.

Fixes #1347