### PR TITLE
Multisite: Posts query error on installs with abnormal site switching (follow-up)

### DIFF
--- a/classes/PublishPress/PermissionsHooks.php
+++ b/classes/PublishPress/PermissionsHooks.php
@@ -686,11 +686,11 @@ class PermissionsHooks
 
         // @todo: require an Advanced setting to be enabled
 		
-        if (preg_match('/SELECT[\s\r\n]+' . $wpdb->base_prefix . '([^\s\r\n]*)posts./', $query, $matches)) {
+        if (preg_match('/FROM[\s\r\n]+' . $wpdb->base_prefix . '([^\s\r\n]*)posts/', $query, $matches)) {
             $posts_table = $wpdb->base_prefix . $matches[1] . 'posts';
 
             // Bypass the safeguard if join clause includes any other posts table
-            if (defined('ADMIN_QUERY_SAFEGUARD_JOIN_PRECAUTION') && !preg_match("/(?!{$posts_table})(" . $wpdb->base_prefix . '[^\s\r\n]*posts)/', $query)) {
+            if (defined('ADMIN_QUERY_SAFEGUARD_JOIN_PRECAUTION') && !preg_match("/JOIN (?!{$posts_table})(" . $wpdb->base_prefix . '[^\s\r\n]*posts)/', $query)) {
                 $query = preg_replace("/$wpdb->base_prefix([^\s\r\n]*)posts\./", $posts_table . '.', $query);
             }
         }


### PR DESCRIPTION
Regular expressions were previously applied to ensure filtered post clauses have matching table prefixes for the currently switched site. These caught most of the problematic queries, but missed those which did not have explicitly qualified column names in the SELECT clause.

Fixes #1297