### PR TITLE
Remove define_create_posts as a Permissions setting

### DIFF
--- a/classes/PublishPress/Permissions/Capabilities.php
+++ b/classes/PublishPress/Permissions/Capabilities.php
@@ -37,7 +37,7 @@ class Capabilities
             'read' => PRESSPERMIT_READ_PUBLIC_CAP,
         ];
 
-        if ($pp->getOption('define_create_posts_cap')) {
+        if (get_option('presspermit_define_create_posts_cap')) {
             foreach (['post', 'page'] as $post_type) {
                 if ($wp_post_types[$post_type]->cap->create_posts == $wp_post_types[$post_type]->cap->edit_posts) {
                     $wp_post_types[$post_type]->cap->create_posts = "create_{$post_type}s";

--- a/classes/PublishPress/Permissions/UI/SettingsTabCore.php
+++ b/classes/PublishPress/Permissions/UI/SettingsTabCore.php
@@ -44,7 +44,6 @@ class SettingsTabCore
             'enabled_taxonomies' => esc_html__('Filtered Taxonomies', 'press-permit-core'),
             'enabled_post_types' => esc_html__('Filtered Post Types', 'press-permit-core'),
             'define_media_post_caps' => esc_html__('Enforce distinct edit, delete capability requirements for Media', 'press-permit-core'),
-            'define_create_posts_cap' => esc_html__('Use create_posts capability', 'press-permit-core'),
         ];
 
         return array_merge($captions, $opt);
@@ -54,7 +53,7 @@ class SettingsTabCore
     {
         $new = [
             'taxonomies' => ['enabled_taxonomies'],
-            'post_types' => ['enabled_post_types', 'define_media_post_caps', 'define_create_posts_cap'],
+            'post_types' => ['enabled_post_types', 'define_media_post_caps'],
             'admin' => [],
         ];
 


### PR DESCRIPTION
... but still apply previously stored setting (still adjustable by PP Capabilities)