### PR TITLE
Revert a string translation change

### DIFF
--- a/classes/PublishPress/Permissions/UI/SettingsTabCore.php
+++ b/classes/PublishPress/Permissions/UI/SettingsTabCore.php
@@ -239,12 +239,18 @@ class SettingsTabCore
 
                                             $url = Settings::pluginInfoURL('capability-manager-enhanced');
 
-                                            $caption = $define_create_posts_cap
-                                                ? 'Post creation capabilities will also be enforced for all Filtered Post Types. To adjust this, install %3$sPublishPress Capabilities%4$s.'
-                                                : 'To enforce capability requirements for post creation, install %3$sPublishPress Capabilities%4$s.';
+                                            $caption = ($define_create_posts_cap)
+                                                ? __(
+                                                    'Post creation capabilities will also be enforced for all Filtered Post Types. To adjust this, install %3$sPublishPress Capabilities%4$s.',
+                                                    'press-permit-core'
+                                                )
+                                                : __(
+                                                    'To enforce capability requirements for post creation, install %3$sPublishPress Capabilities%4$s.',
+                                                    'press-permit-core'
+                                                );
                                             
                                             printf(
-                                                esc_html__($caption, 'press-permit-core'),
+                                                esc_html($caption),
                                                 '<span class="pp-important">',
                                                 '</span>',
                                                 '<span class="plugins update-message"><a href="' . esc_url($url) . '" class="thickbox" title="' . esc_attr__('PublishPress Capabilities', 'press-permit-core') . '">',

--- a/classes/PublishPress/Permissions/UI/SettingsTabCore.php
+++ b/classes/PublishPress/Permissions/UI/SettingsTabCore.php
@@ -253,7 +253,7 @@ class SettingsTabCore
                                                 esc_html($caption),
                                                 '<span class="pp-important">',
                                                 '</span>',
-                                                '<span class="plugins update-message"><a href="' . esc_url($url) . '" class="thickbox" title="' . esc_attr__('PublishPress Capabilities', 'press-permit-core') . '">',
+                                                '<span class="plugins update-message"><a href="' . esc_url($url) . '" class="thickbox" title="' . esc_attr('PublishPress Capabilities') . '">',
                                                 '</a></span>'
                                             );
                                         }


### PR DESCRIPTION
Put strings directly in translation function argument so they are properly added to the .pot file.