### PR TITLE
PHP Warning on post update under some conditions

### DIFF
--- a/modules/presspermit-collaboration/classes/Permissions/Collab/PostTermsSave.php
+++ b/modules/presspermit-collaboration/classes/Permissions/Collab/PostTermsSave.php
@@ -220,6 +220,10 @@ class PostTermsSave
             return $terms;
         }
 
+        if (null === $terms) {
+            $terms = [];
+        }
+
         if (is_string($terms) || (!is_taxonomy_hierarchical($taxonomy))) {  // non-hierarchical taxonomy (tags)
             if (is_string($terms)) {
                 $term_info = self::parseTermNames($terms, $taxonomy);


### PR DESCRIPTION
Fixes #1624

If terms were filtered to null upstream, set to empty array.