### PR TITLE
Permissions list: remember last Group Type / All Users / Users with Permissions selection

### DIFF
--- a/classes/PublishPress/Permissions/UI/Dashboard/UsersListing.php
+++ b/classes/PublishPress/Permissions/UI/Dashboard/UsersListing.php
@@ -294,7 +294,7 @@ class UsersListing
 
     public static function fltUserQueryExceptions($query_obj)
     {
-        global $wpdb;
+        global $wpdb, $current_user, $pagenow;
 
         // Filter the Users Query to support various group filtering / sorting parameters
 
@@ -322,7 +322,13 @@ class UsersListing
             $query_obj->query_where .= " AND ID IN ( SELECT agent_id FROM $wpdb->ppc_roles WHERE agent_type = 'user' )";
         }
 
-        if (!PWP::empty_REQUEST('pp_user_perms')) {
+        if (!PWP::is_REQUEST('pp_user_perms') && (empty($pagenow) || ('users.php' != $pagenow))) {
+            $pp_user_perms = get_user_option('pp_user_perms');
+        } else {
+            $pp_user_perms = !PWP::empty_REQUEST('pp_user_perms');
+        }
+        
+        if ($pp_user_perms) {
             $query_obj->query_where .= " AND ( ID IN ( SELECT agent_id FROM $wpdb->ppc_roles"
                 . " WHERE agent_type = 'user' ) OR ID IN ( SELECT agent_id FROM $wpdb->ppc_exceptions AS e"
                 . " INNER JOIN $wpdb->ppc_exception_items AS i ON e.exception_id = i.exception_id"
@@ -343,7 +349,13 @@ class UsersListing
                 . " INNER JOIN $wpdb->ppc_roles AS r ON r.agent_id = ug.group_id AND r.agent_type = 'pp_group' )";
         }
 
-        if (!PWP::empty_REQUEST('pp_has_perms')) {
+        if (!PWP::is_REQUEST('pp_has_perms') && (empty($pagenow) || ('users.php' != $pagenow))) {
+            $pp_has_perms = get_user_option('pp_has_perms');
+        } else {
+            $pp_has_perms = !PWP::empty_REQUEST('pp_has_perms');
+        }
+
+        if (!$pp_has_perms) {
             $query_obj->query_where .= " AND ( ID IN ( SELECT agent_id FROM $wpdb->ppc_exceptions AS e"
                 . " INNER JOIN $wpdb->ppc_exception_items AS i ON e.exception_id = i.exception_id"
                 . " WHERE e.agent_type = 'user' )"

--- a/classes/PublishPress/Permissions/UI/Groups.php
+++ b/classes/PublishPress/Permissions/UI/Groups.php
@@ -6,6 +6,8 @@ class Groups
 {
     public function __construct()
     {
+        global $current_user;
+
         // called by Dashboard\DashboardFilters::actMenuHandler
 
         $pp = presspermit();
@@ -37,15 +39,23 @@ class Groups
             $action = '';
         }
 
-        $active_tab = isset($_GET['tab']) ? $_GET['tab'] : 'user-group';
-
+        if (!$active_tab = PWP::REQUEST_key('tab')) {
+            $active_tab = 'user-group';
+        }
+    
         if ('users' == $active_tab) {
             $agent_type = 'user';
             $group_variant = '';
         } else {
             if (!in_array($action, ['delete', 'bulkdelete'])) {
-                if (!$agent_type = PWP::REQUEST_key('agent_type')) {
-                    $agent_type = 'pp_group';
+                if (!PWP::is_REQUEST('agent_type') && PWP::empty_REQUEST('pp_has_perms') && PWP::empty_REQUEST('pp_user_perms')) {
+                    $agent_type = get_user_option('pp_agent_type');
+                } else {
+                    if (!$agent_type = PWP::REQUEST_key('agent_type')) {
+                        $agent_type = 'pp_group';
+                    }
+
+                    update_user_option($current_user->ID, 'pp_agent_type', $agent_type);
                 }
             } else {
                 $agent_type = '';
@@ -233,24 +243,31 @@ class Groups
 
                             $class = (!$group_variant) ? 'current' : '';
 
-                            echo "<li><a href='admin.php?page=presspermit-groups' class='" . esc_attr($class) . "'>" . esc_html__('All', 'press-permit-core') . "</a>&nbsp;|&nbsp;</li>";
+                            if (!PWP::is_REQUEST('pp_has_perms')) {
+                                $pp_has_perms = get_user_option('pp_has_perms');
+                            } else {
+                                $pp_has_perms = !PWP::empty_REQUEST('pp_has_perms');
+                                update_user_option($current_user->ID, 'pp_has_perms', $pp_has_perms);
+                            }
+
+                            echo "<li><a href='admin.php?page=presspermit-groups&pp_has_perms=0' class='" . esc_attr($class) . "'>" . esc_html__('All', 'press-permit-core') . "</a>&nbsp;|&nbsp;</li>";
 
                             $i = 0;
                             foreach ($group_types as $_group_type => $gtype_obj) {
                                 $agent_type_str = (in_array($_group_type, ['wp_role', 'login_state'], true)) ? "&agent_type=pp_group" : "&agent_type=$_group_type";
                                 $gvar_str = "&group_variant=$_group_type";
-                                $class = strpos($agent_type_str, $agent_type) && ($group_variant && strpos($gvar_str, $group_variant) && empty($_REQUEST['pp_has_perms'])) ? 'current' : '';
+                                $class = strpos($agent_type_str, $agent_type) && ($group_variant && strpos($gvar_str, $group_variant) && empty($pp_has_perms)) ? 'current' : '';
 
                                 $group_label = (!empty($gtype_obj->labels->plural_name)) ? $gtype_obj->labels->plural_name : $gtype_obj->labels->singular_name;
 
                                 $i++;
 
-                                echo "<li><a href='" . esc_url("admin.php?page=presspermit-groups{$agent_type_str}{$gvar_str}") . "' class='" . esc_attr($class) . "'>" . esc_html($group_label) . "</a>";
+                                echo "<li><a href='" . esc_url("admin.php?page=presspermit-groups&pp_has_perms=0{$agent_type_str}{$gvar_str}") . "' class='" . esc_attr($class) . "'>" . esc_html($group_label) . "</a>";
                                 echo "&nbsp;|&nbsp;";
                                 echo '</li>';
                             }
 
-                            $class = !empty($_REQUEST['pp_has_perms']) ? 'current' : '';
+                            $class = !empty($pp_has_perms) ? 'current' : '';
                             echo "<li><a href='" . esc_url("admin.php?page=presspermit-groups&pp_has_perms=1") . "' class='" . esc_attr($class) . "'>" . esc_html__('Groups with Permissions', 'presspermit-core') . "</a></li>";
 
                             echo '</ul>';
@@ -273,20 +290,30 @@ class Groups
                         </div>
                     </div>
 
+                    <?php
+                    if (!PWP::is_REQUEST('pp_user_perms')) {
+                        $pp_user_perms = get_user_option('pp_user_perms');
+                    } else {
+                        $pp_user_perms = !PWP::empty_REQUEST('pp_user_perms');
+            
+                        update_user_option($current_user->ID, 'pp_user_perms', $pp_user_perms);
+                    }
+                    ?>
+
                     <div id="users" class="tab-content"
                         style="<?php echo ($active_tab === 'users') ? 'display:block;' : 'display:none;'; ?>">
                         <div class="presspermit-groups">
                             <div class="pp-hint pp-no-hide"></div>
                             <ul class="subsubsub">
                                 <li>
-                                    <a href="<?php echo esc_url(admin_url('admin.php?page=presspermit-groups&tab=users')); ?>"
-                                        class="<?php echo empty($_GET['pp_user_perms']) ? 'current' : ''; ?>">
+                                    <a href="<?php echo esc_url(admin_url('admin.php?page=presspermit-groups&tab=users&pp_user_perms=0')); ?>"
+                                        class="<?php echo empty($pp_user_perms) ? 'current' : ''; ?>">
                                         <?php esc_html_e('All Users', 'press-permit-core'); ?>
                                     </a>&nbsp;|&nbsp;
                                 </li>
                                 <li>
                                     <a href="<?php echo esc_url(admin_url('admin.php?page=presspermit-groups&tab=users&pp_user_perms=1')); ?>"
-                                        class="<?php echo !empty($_GET['pp_user_perms']) ? 'current' : ''; ?>">
+                                        class="<?php echo !empty($pp_user_perms) ? 'current' : ''; ?>">
                                         <?php esc_html_e('Users with Permissions set directly', 'press-permit-core'); ?>
                                     </a>
                                 </li>
@@ -295,7 +322,7 @@ class Groups
                                 <input type="hidden" name="page" value="presspermit-groups" />
                                 <input type="hidden" name="tab" value="users" />
                                 <?php
-                                if (!empty(PWP::REQUEST_key('pp_user_perms'))) {
+                                if ($pp_user_perms) {
                                     echo '<input type="hidden" name="pp_user_perms" value="1" />';
                                 }
                                 if (isset($users_list_table)) {

--- a/classes/PublishPress/Permissions/UI/GroupsQuery.php
+++ b/classes/PublishPress/Permissions/UI/GroupsQuery.php
@@ -116,7 +116,13 @@ class GroupQuery
             $this->query_where .= " AND $groups_table.metagroup_type != 'rvy_notice'";  // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
         }
 
-        if (!empty($_REQUEST['pp_has_perms'])) {
+        if (!PWP::is_REQUEST('pp_has_perms')) {
+            $pp_has_perms = get_user_option('pp_has_perms');
+        } else {
+            $pp_has_perms = !PWP::empty_REQUEST('pp_has_perms');
+        }
+
+        if (!empty($pp_has_perms)) {
             $this->query_where .= " AND ( ID IN ( SELECT agent_id FROM $wpdb->ppc_exceptions AS e"
                 . " INNER JOIN $wpdb->ppc_exception_items AS i ON e.exception_id = i.exception_id"
                 . " WHERE e.agent_type = 'user' )"

--- a/classes/PublishPress/Permissions/UI/PluginPage.php
+++ b/classes/PublishPress/Permissions/UI/PluginPage.php
@@ -76,7 +76,10 @@ class PluginPage
             $group_variant = self::getGroupVariant();
 
             if ( ! $this->table = apply_filters('presspermit_groups_list_table', false, $agent_type) ) {
-                $active_tab = isset($_GET['tab']) ? $_GET['tab'] : 'user-group';
+                if (!$active_tab = PWP::REQUEST_key('tab')) {
+                    $active_tab = 'user-group';
+                }
+
                 if ($active_tab === 'users') {
                     require_once(PRESSPERMIT_CLASSPATH . '/UI/UsersListTable.php' );
                     $this->table_user = new UsersListTable();
@@ -126,7 +129,16 @@ class PluginPage
         }
 
         if (empty($group_variant)) {
-            $group_variant = PWP::REQUEST_key('group_variant');
+            global $current_user;
+
+            if (!PWP::is_REQUEST('group_variant') && PWP::empty_REQUEST('pp_has_perms') && PWP::empty_REQUEST('pp_user_perms')) {
+                if (!$group_variant = get_user_option('pp_group_variant')) {
+                    $group_variant = '';
+                }
+            } else {
+                $group_variant = PWP::REQUEST_key('group_variant');
+                update_user_option($current_user->ID, 'pp_group_variant', $group_variant);
+            }
         }
 
         return sanitize_key(apply_filters('presspermit_query_group_variant', $group_variant));

--- a/classes/PublishPress/Permissions/UI/UsersListTable.php
+++ b/classes/PublishPress/Permissions/UI/UsersListTable.php
@@ -53,6 +53,13 @@ class UsersListTable extends \WP_List_Table
                 'style' => (!PWP::empty_REQUEST('pp_has_exceptions')) ? 'style="font-weight:bold; color:black"' : '',
             ],
         ];
+
+        if (!PWP::is_REQUEST('pp_user_perms')) {
+            $pp_user_perms = get_user_option('pp_user_perms');
+        } else {
+            $pp_user_perms = !PWP::empty_REQUEST('pp_user_perms');
+        }
+
         $columns = [
             'cb' => '<input type = "checkbox" />',
             'user_login' => __('Username', 'press-permit-core'),
@@ -65,14 +72,14 @@ class UsersListTable extends \WP_List_Table
             ),
             'pp_groups' => __('Groups', 'press-permit-core'),
             'pp_exceptions' => sprintf(
-                (empty($_REQUEST['pp_has_exceptions'])) ? esc_html__('User Permissions %1$s%2$s', 'press-permit-core') : esc_html__('Specific Permissions %1$s%2$s', 'press-permit-core'),
-                (empty($_REQUEST['pp_user_perms'])) ? '<a href="' . esc_url(add_query_arg('pp_has_exceptions', intval(empty($_REQUEST['pp_has_exceptions'])))) . '" title="' . esc_attr($column_attr['pp_exceptions']['title']) . '" ' . $column_attr['pp_exceptions']['style'] . '>*' : '',
-                (empty($_REQUEST['pp_user_perms'])) ? '</a>' : ''
+                (PWP::empty_REQUEST('pp_has_exceptions')) ? esc_html__('User Permissions %1$s%2$s', 'press-permit-core') : esc_html__('Specific Permissions %1$s%2$s', 'press-permit-core'),
+                (empty($pp_user_perms)) ? '<a href="' . esc_url(add_query_arg('pp_has_exceptions', intval(PWP::empty_REQUEST('pp_has_exceptions')))) . '" title="' . esc_attr($column_attr['pp_exceptions']['title']) . '" ' . $column_attr['pp_exceptions']['style'] . '>*' : '',
+                (empty($pp_user_perms)) ? '</a>' : ''
             ),
             'pp_roles' => sprintf(
-                (empty($_REQUEST['pp_has_roles'])) ? esc_html__('User Roles %1$s%2$s', 'press-permit-core') : esc_html__('Extra Roles %1$s%2$s', 'press-permit-core'),
-                (empty($_REQUEST['pp_user_perms'])) ? '<a href="' . esc_url(add_query_arg('pp_has_roles', intval(empty($_REQUEST['pp_has_roles'])))) . '" title="' . esc_attr($column_attr['pp_roles']['title']) . '" ' . $column_attr['pp_roles']['style'] . '>*' : '',
-                (empty($_REQUEST['pp_user_perms'])) ? '</a>' : ''
+                (PWP::empty_REQUEST('pp_has_roles')) ? esc_html__('User Roles %1$s%2$s', 'press-permit-core') : esc_html__('Extra Roles %1$s%2$s', 'press-permit-core'),
+                (empty($pp_user_perms)) ? '<a href="' . esc_url(add_query_arg('pp_has_roles', intval(PWP::empty_REQUEST('pp_has_roles')))) . '" title="' . esc_attr($column_attr['pp_roles']['title']) . '" ' . $column_attr['pp_roles']['style'] . '>*' : '',
+                (empty($pp_user_perms)) ? '</a>' : ''
             ),
         ];
         return $columns;


### PR DESCRIPTION
If this administrator viewed "Users with Permissions" last time, default to that view on the next Permissions > Users visit.

Also do the same for Permissions > User Groups > Group Type