### PR TITLE
fix an error of type E_ERROR crash report in AgentPermissionsAjax.php

### DIFF
--- a/classes/PublishPress/Permissions/UI/AgentPermissionsAjax.php
+++ b/classes/PublishPress/Permissions/UI/AgentPermissionsAjax.php
@@ -283,7 +283,9 @@ class AgentPermissionsAjax
                     echo '<!--ppResponse-->' . 'exceptions_mirror' . '~' . esc_attr(implode('|', $edited_input_ids)) . '<--ppResponse-->';
                     break;
                 } elseif (0 === strpos($action, 'exceptions_convert_')) {
-                    
+
+                    require_once(PRESSPERMIT_CLASSPATH . '/DB/PermissionsUpdate.php');
+
                     $arr = explode('_', $action);
 
                     if (count($arr) < 3) {


### PR DESCRIPTION
Fixed https://github.com/publishpress/PublishPress-Permissions/issues/1731