### PR TITLE
Edit Permissions: "None" caption in term selection box has untranslated string

### DIFF
--- a/classes/PublishPress/Permissions/UI/ItemsMetabox.php
+++ b/classes/PublishPress/Permissions/UI/ItemsMetabox.php
@@ -293,9 +293,10 @@ class ItemsMetabox extends \Walker_Nav_Menu
 
                     <?php
                     $args['walker'] = $walker;
+                    $post_type_name_formatted = ucwords(str_replace('-', ' ', trim($post_type_name)));
 
                     // kevinB: add "(none)" item for include exceptions
-                    $override_none = sprintf(esc_html__('None. All %ss will be hidden by default.', 'press-permit-core'), ucwords($post_type_name));
+                    $override_none = sprintf(esc_html__('None. All %ss will be hidden by default.', 'press-permit-core'), $post_type_name_formatted);
                     $front_page_obj = (object)['ID' => 0, 'post_parent' => 0, 'post_content' => '', 'post_excerpt' => '', 'post_title' => esc_html__('(none)', 'press-permit-core'), 'object_id' => 0, 'title' => $override_none, 'menu_item_parent' => 0, 'db_id' => 0];
                     $front_page_obj->_add_to_top = true;
                     $front_page_obj->label = esc_html__('(none)', 'press-permit-core');


### PR DESCRIPTION
Fixes #1961