### PR TITLE
Prevent term ancestor count loops

### DIFF
--- a/classes/PublishPress/Permissions/TermQuery.php
+++ b/classes/PublishPress/Permissions/TermQuery.php
@@ -4,7 +4,7 @@ namespace PublishPress\Permissions;
 
 class TermQuery
 {
-    // derived from WP _pad_term_counts(), but includes private posts in counts based on current user's access 
+    // derived from WP _pad_term_counts(), but includes private posts in counts based on current user's access
     public static function tallyTermCounts(&$terms, $taxonomy, $args = [])
     {
         global $wpdb;
@@ -20,6 +20,8 @@ class TermQuery
         }
 
         $term_items = [];
+        $terms_by_id = [];
+        $term_ids = [];
 
         if ($terms) {
             if (!is_object(reset($terms))) {
@@ -98,21 +100,35 @@ class TermQuery
 
         foreach ($results as $row) {
             $id = $term_ids[$row->term_taxonomy_id];
-            $term_items[$id][$row->object_id] = isset($term_items[$id][$row->object_id]) ? ++$term_items[$id][$row->object_id] : 1;
+            $term_items[$id][$row->object_id] = 1;
         }
+
+        $max_depth = count($terms_by_id);
 
         // Touch every ancestor's lookup row for each post in each term
         foreach ($term_ids as $term_id) {
-            $child = $term_id;  // phpcs:ignore WordPress.CodeAnalysis.AssignmentInCondition.FoundInWhileCondition
+            $child = $term_id;
+            $seen = [];
+            $depth = 0;
 
-            while (!empty($terms_by_id[$child]) && $parent = $terms_by_id[$child]->parent) {  // phpcs:ignore WordPress.CodeAnalysis.AssignmentInCondition.FoundInWhileCondition
+            while (!empty($terms_by_id[$child]) && $parent = (int) $terms_by_id[$child]->parent) {  // phpcs:ignore WordPress.CodeAnalysis.AssignmentInCondition.FoundInWhileCondition
+                if (
+                    isset($seen[$child])
+                    || isset($seen[$parent])
+                    || ++$depth > $max_depth
+                    || empty($terms_by_id[$parent])
+                ) {
+                    break;
+                }
+
                 if (!empty($term_items[$term_id])) {
                     foreach ($term_items[$term_id] as $item_id => $touches) {
-                        $term_items[$parent][$item_id] = isset($term_items[$parent][$item_id]) ? ++$term_items[$parent][$item_id] : 1;
+                        $term_items[$parent][$item_id] = 1;
                     }
                 }
 
-                $child = $parent;  // phpcs:ignore WordPress.CodeAnalysis.AssignmentInCondition.FoundInWhileCondition
+                $seen[$child] = true;
+                $child = $parent;
             }
         }
 


### PR DESCRIPTION
**Note**: Maybe some better handling or notice can be provided.  I mostly just want to demonstrate a safeguard, as we've observed this thrashing CPU on sites at the WP Cloud hosting level.

## Summary

Make term count padding stop cleanly when hierarchical taxonomy data contains a circular or invalid parent chain. 

This prevents malformed term ancestry from sending requests into an unbounded loop until PHP reaches max execution time. This caused long-running PHP workers and elevated CPU usage.

The issue was observed in the Pro package, which includes this shared core plugin code, with fatals like:

```text
PHP Fatal error: Maximum execution time of 850 seconds exceeded in .../classes/PublishPress/Permissions/TermQuery.php on line 109
```

## Details

The previous ancestor walk assumed every parent chain eventually reached `0`. That is true for healthy term data, but a self-parented term or longer cycle can keep the loop running indefinitely.

E.g., 

`term_id 16882 -> parent 16882`

or longer circular chains.

In those cases, this loop never terminates:

```
while (!empty($terms_by_id[$child]) && $parent = $terms_by_id[$child]->parent) {
    ...
    $child = $parent;
}
```

This change tracks visited terms while walking ancestors and stops padding when the chain repeats, exceeds the number of known terms, or points to a parent that is not in the loaded term set. For valid hierarchies, padded counts should continue to behave the same way.

* Adds explicit initialization for $terms_by_id and $term_ids.
* Tracks visited term IDs while walking parent chains.
* Stops ancestor traversal when:
  * the current child term has already been seen,
  * the next parent has already been seen,
  * traversal exceeds the number of known terms,
  * the parent term is not present in the loaded term set.
* Treats $term_items values as set membership markers instead of incrementing counters, since final counts are based on count($items).

## Risk / Compatibility
This should not change behavior for valid term hierarchies.

For malformed hierarchies, the behavior changes from “potential fatal / request timeout” to “stop padding counts once the invalid ancestor chain is detected.” That means sites with corrupt circular parent data may still have imperfect padded counts for the affected broken branch, but requests should complete instead of exhausting PHP execution time.

## Validation

- `php -l classes/PublishPress/Permissions/TermQuery.php`
- Targeted PHPCS against `classes/PublishPress/Permissions/TermQuery.php`
- PHPCompatibility check for `classes/PublishPress/Permissions/TermQuery.php` with `testVersion 7.2-`
- Local reproduction confirmed circular ancestor chains terminate after this change

Full-repo PHPCS still reports unrelated pre-existing escaping issues in `classes/PublishPress/Permissions/UI/SettingsTabAdvanced.php`.
