### PR TITLE
Fix #2421: restore restricted term checklist hierarchy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+[4.8.4-alpha.1] - 24 Aug, 2026
+
+- Fixed: Nested Assign-Term restrictions now preserve their hierarchy in post editor term checklists. #2421
+
 [4.8.3] - 24 Aug, 2026
 
 - Added: An option to enable or disable role-level editing restrictions in User Management. #2419

--- a/classes/PublishPress/Permissions/TermFilters.php
+++ b/classes/PublishPress/Permissions/TermFilters.php
@@ -16,7 +16,7 @@ class TermFilters
     private $parent_remap_enabled = true;
     private $count_filters_obj;
     private $disable_next_count_filtering = false;
-    private $hierarchy_normalize_taxonomies = [];
+    private $hierarchy_remap_taxonomies = [];
 
     public function __construct()
     {
@@ -24,7 +24,7 @@ class TermFilters
         add_filter('get_terms_args', [$this, 'fltGetTermsRestoreArgs'], 51, 2);
 
         add_filter('terms_clauses', [$this, 'fltTermsClauses'], 50, 3);
-        add_filter('get_terms', [$this, 'fltNormalizeTermHierarchy'], 20, 3);
+        add_filter('get_terms', [$this, 'fltRemapTermHierarchy'], 20, 3);
 
         if (!presspermit()->isUserUnfiltered())
             add_filter('get_the_terms', [$this, 'fltGetTheTerms'], 10, 3);
@@ -314,6 +314,7 @@ class TermFilters
         // NOTE: If hide_empty is true, additional filtering will be applied to the results based on a full posts query.  
         // Posts may have direct restrictions which make them inaccessable regardless of term restrictions.
         $all_excluded_ttids = [];
+        $filtered_taxonomies = [];
 
         $enabled_types = presspermit()->getEnabledPostTypes();
         $required_operation = $args['required_operation'];
@@ -321,15 +322,6 @@ class TermFilters
         foreach ($taxonomies as $taxonomy) {
             $excluded_ttids = $included_ttids = [];
             $any_non_inclusions = false;
-
-            // A restricted (assign/manage) term set can omit a returned term's ancestor(s), which
-            // leaves Walker_Category_Checklist (used by wp_terms_checklist() in the post editor) unable
-            // to place that term correctly: it falls back to treating an arbitrary term as the tree
-            // root instead of the actually-restricted one. Flag the taxonomy so the get_terms filter
-            // below can mark any such orphaned term as a root once the final term set is known.
-            if (in_array($required_operation, ['assign', 'manage'], true) && is_taxonomy_hierarchical($taxonomy)) {
-                $this->hierarchy_normalize_taxonomies[$taxonomy] = true;
-            }
 
             if (!in_array($required_operation, ['manage', 'associate'], true)) {
                 $universal = [];
@@ -457,9 +449,12 @@ class TermFilters
                 if ($exc) {
                     // but don't exclude a term which is explicitly included for one or more post types
                     if (count($exception_types) > 1) {
-                        $all_excluded_ttids = array_merge($all_excluded_ttids, array_diff($exc, $included_ttids));
-                    } else {
+                        $exc = array_diff($exc, $included_ttids);
+                    }
+
+                    if ($exc) {
                         $all_excluded_ttids = array_merge($all_excluded_ttids, $exc);
+                        $filtered_taxonomies[$taxonomy] = true;
                     }
                 }
             }
@@ -478,6 +473,8 @@ class TermFilters
                     $clauses['where'] .= " AND ( tt.taxonomy != '$taxonomy' "
                         . "OR tt.term_taxonomy_id IN ('" . implode("','", array_unique($included_ttids)) . "') )";
                 }
+
+                $filtered_taxonomies[$taxonomy] = true;
             }
         }
 
@@ -490,47 +487,50 @@ class TermFilters
             $clauses['where'] .= " AND tt.term_taxonomy_id NOT IN ('" . implode("','", $all_excluded_ttids) . "')";
         }
 
+        if (('all' == ($args['get'] ?? '')) && empty($args['parent'])
+        && in_array($required_operation, ['assign', 'manage'], true)
+        ) {
+            foreach (array_keys($filtered_taxonomies) as $taxonomy) {
+                if (is_taxonomy_hierarchical($taxonomy)) {
+                    $this->hierarchy_remap_taxonomies[$taxonomy] = true;
+                }
+            }
+        }
+
         return $clauses;
     }
 
     /**
-     * Fix hierarchy for a restricted (assign/manage) term set: a term whose parent was filtered
-     * out of the returned set (because the user isn't permitted to see that ancestor) still carries
-     * the original, absent parent id. WP's Walker_Category_Checklist then has no true top-level
-     * element to build the tree from and falls back to treating an arbitrary term as root, which
-     * scrambles the checklist (see #2421). Re-root any such orphaned term to 0 so the walker treats
-     * it as the subtree root it actually is.
+     * Restore hierarchy for a restricted wp_terms_checklist() result.
      */
-    public function fltNormalizeTermHierarchy($terms, $taxonomies, $args)
+    public function fltRemapTermHierarchy($terms, $taxonomies, $args)
     {
-        // Consume (and clear) the flag set for this get_terms() call, regardless of outcome below,
-        // so it can never bleed into a later, unrelated call.
-        $normalize_taxonomies = $this->hierarchy_normalize_taxonomies;
-        $this->hierarchy_normalize_taxonomies = [];
+        $remap_taxonomies = $this->hierarchy_remap_taxonomies;
+        $this->hierarchy_remap_taxonomies = [];
+        $taxonomies = (array) $taxonomies;
 
-        if (empty($normalize_taxonomies) || empty($terms) || !is_array($terms)) {
+        if (empty($remap_taxonomies) || empty($terms) || !is_array($terms) || (1 != count($taxonomies))) {
             return $terms;
         }
 
-        if (!is_object(reset($terms))) {
+        $taxonomy = reset($taxonomies);
+        if (empty($remap_taxonomies[$taxonomy]) || !is_object(reset($terms))) {
             return $terms;
         }
 
-        $present_ids = [];
-        foreach ($terms as $term) {
-            if (isset($term->term_id)) {
-                $present_ids[$term->term_id] = true;
-            }
-        }
+        require_once(PRESSPERMIT_CLASSPATH_COMMON . '/Ancestry.php');
 
-        foreach ($terms as $term) {
-            if (
-                !empty($term->taxonomy) && !empty($normalize_taxonomies[$term->taxonomy])
-                && !empty($term->parent) && empty($present_ids[$term->parent])
-            ) {
-                $term->parent = 0;
-            }
-        }
+        $ancestors = \PressShack\Ancestry::getTermAncestors($taxonomy);
+        $remap_args = [
+            'child_of' => (int) ($args['child_of'] ?? 0),
+            'parent' => (int) ($args['parent'] ?? 0),
+            'exclude' => $args['exclude'] ?? false, // phpcs:ignore WordPressVIPMinimum.Performance.WPQueryParams.PostNotIn_exclude
+            'orderby' => $args['orderby'] ?? 'name',
+            'col_id' => 'term_id',
+            'col_parent' => 'parent',
+        ];
+
+        \PressShack\Ancestry::remapTree($terms, $ancestors, $remap_args);
 
         return $terms;
     }

--- a/classes/PublishPress/Permissions/TermFilters.php
+++ b/classes/PublishPress/Permissions/TermFilters.php
@@ -16,6 +16,7 @@ class TermFilters
     private $parent_remap_enabled = true;
     private $count_filters_obj;
     private $disable_next_count_filtering = false;
+    private $hierarchy_normalize_taxonomies = [];
 
     public function __construct()
     {
@@ -23,6 +24,7 @@ class TermFilters
         add_filter('get_terms_args', [$this, 'fltGetTermsRestoreArgs'], 51, 2);
 
         add_filter('terms_clauses', [$this, 'fltTermsClauses'], 50, 3);
+        add_filter('get_terms', [$this, 'fltNormalizeTermHierarchy'], 20, 3);
 
         if (!presspermit()->isUserUnfiltered())
             add_filter('get_the_terms', [$this, 'fltGetTheTerms'], 10, 3);
@@ -320,6 +322,15 @@ class TermFilters
             $excluded_ttids = $included_ttids = [];
             $any_non_inclusions = false;
 
+            // A restricted (assign/manage) term set can omit a returned term's ancestor(s), which
+            // leaves Walker_Category_Checklist (used by wp_terms_checklist() in the post editor) unable
+            // to place that term correctly: it falls back to treating an arbitrary term as the tree
+            // root instead of the actually-restricted one. Flag the taxonomy so the get_terms filter
+            // below can mark any such orphaned term as a root once the final term set is known.
+            if (in_array($required_operation, ['assign', 'manage'], true) && is_taxonomy_hierarchical($taxonomy)) {
+                $this->hierarchy_normalize_taxonomies[$taxonomy] = true;
+            }
+
             if (!in_array($required_operation, ['manage', 'associate'], true)) {
                 $universal = [];
                 $universal['include'] = $user->getExceptionTerms($required_operation, 'include', '', $taxonomy);
@@ -480,5 +491,47 @@ class TermFilters
         }
 
         return $clauses;
+    }
+
+    /**
+     * Fix hierarchy for a restricted (assign/manage) term set: a term whose parent was filtered
+     * out of the returned set (because the user isn't permitted to see that ancestor) still carries
+     * the original, absent parent id. WP's Walker_Category_Checklist then has no true top-level
+     * element to build the tree from and falls back to treating an arbitrary term as root, which
+     * scrambles the checklist (see #2421). Re-root any such orphaned term to 0 so the walker treats
+     * it as the subtree root it actually is.
+     */
+    public function fltNormalizeTermHierarchy($terms, $taxonomies, $args)
+    {
+        // Consume (and clear) the flag set for this get_terms() call, regardless of outcome below,
+        // so it can never bleed into a later, unrelated call.
+        $normalize_taxonomies = $this->hierarchy_normalize_taxonomies;
+        $this->hierarchy_normalize_taxonomies = [];
+
+        if (empty($normalize_taxonomies) || empty($terms) || !is_array($terms)) {
+            return $terms;
+        }
+
+        if (!is_object(reset($terms))) {
+            return $terms;
+        }
+
+        $present_ids = [];
+        foreach ($terms as $term) {
+            if (isset($term->term_id)) {
+                $present_ids[$term->term_id] = true;
+            }
+        }
+
+        foreach ($terms as $term) {
+            if (
+                !empty($term->taxonomy) && !empty($normalize_taxonomies[$term->taxonomy])
+                && !empty($term->parent) && empty($present_ids[$term->parent])
+            ) {
+                $term->parent = 0;
+            }
+        }
+
+        return $terms;
     }
 }

--- a/press-permit-core.php
+++ b/press-permit-core.php
@@ -4,7 +4,7 @@
  * Plugin Name: PublishPress Permissions Free
  * Plugin URI:  https://publishpress.com/presspermit
  * Description: PublishPress Permissions allows you to enable or deny access to posts, pages, categories, tags and more.
- * Version: 4.8.3
+ * Version: 4.8.4-alpha.1
  * Author: PublishPress
  * Author URI:  https://publishpress.com/
  * Text Domain: press-permit-core
@@ -209,7 +209,7 @@ if ((!defined('PRESSPERMIT_FILE') && !$pro_active) || $presspermit_loaded_by_pro
             return;
         }
 
-        define('PRESSPERMIT_VERSION', '4.8.3');
+        define('PRESSPERMIT_VERSION', '4.8.4-alpha.1');
 
         if (!defined('PRESSPERMIT_READ_PUBLIC_CAP')) {
             define('PRESSPERMIT_READ_PUBLIC_CAP', 'read');

--- a/readme.txt
+++ b/readme.txt
@@ -5,7 +5,7 @@ Tags: permissions, access, restrict, privacy, capabilities
 Requires at least: 5.5
 Tested up to: 7.1
 Requires PHP: 7.2.5
-Stable tag: 4.8.3
+Stable tag: 4.8.4-alpha.1
 License: GPLv3
 License URI: https://www.gnu.org/licenses/gpl-3.0.html
 

--- a/tests/manual/issue-2421-term-checklist.php
+++ b/tests/manual/issue-2421-term-checklist.php
@@ -1,0 +1,189 @@
+<?php
+
+/**
+ * Manual integration regression test for issue #2421.
+ *
+ * Run this file after loading WordPress in an admin context with the
+ * Collaboration module active. The test creates and removes its own user,
+ * terms and exceptions.
+ */
+
+if (!defined('ABSPATH')) {
+    fwrite(STDERR, "WordPress must be loaded before running this test.\n");
+    exit(1);
+}
+
+if (!is_admin() || !presspermit()->moduleActive('collaboration')) {
+    fwrite(STDERR, "Run this test in an admin context with the Collaboration module active.\n");
+    exit(1);
+}
+
+$assert = static function ($condition, $message) {
+    if (!$condition) {
+        throw new RuntimeException($message);
+    }
+};
+
+global $pagenow;
+
+$original_user_id = get_current_user_id();
+$original_pagenow = $pagenow ?? null;
+$pagenow = 'post.php';
+
+$test_suffix = strtolower(wp_generate_password(8, false, false));
+$test_user_id = 0;
+$test_term_ids = [];
+$failure = null;
+
+try {
+    $test_user_id = wp_insert_user([
+        'user_login' => "pp2421_{$test_suffix}",
+        'user_pass' => wp_generate_password(24, true, true),
+        'user_email' => "pp2421_{$test_suffix}@example.com",
+        'role' => 'contributor',
+    ]);
+    $assert(!is_wp_error($test_user_id), 'Could not create the test user.');
+
+    $term_names = [
+        'top' => "PP2421 {$test_suffix} Top",
+        'middle' => "PP2421 {$test_suffix} Middle",
+        'child_a' => "PP2421 {$test_suffix} Child A",
+        'child_b' => "PP2421 {$test_suffix} Child B",
+        'grandchild_a' => "PP2421 {$test_suffix} Grandchild A",
+        'grandchild_b' => "PP2421 {$test_suffix} Grandchild B",
+    ];
+
+    $top = wp_insert_term($term_names['top'], 'category');
+    $assert(!is_wp_error($top), 'Could not create the top-level term.');
+    $test_term_ids[] = $top['term_id'];
+
+    $middle = wp_insert_term($term_names['middle'], 'category', ['parent' => $top['term_id']]);
+    $assert(!is_wp_error($middle), 'Could not create the restricted term.');
+    $test_term_ids[] = $middle['term_id'];
+
+    $child_a = wp_insert_term($term_names['child_a'], 'category', ['parent' => $middle['term_id']]);
+    $assert(!is_wp_error($child_a), 'Could not create Child A.');
+    $test_term_ids[] = $child_a['term_id'];
+
+    $child_b = wp_insert_term($term_names['child_b'], 'category', ['parent' => $middle['term_id']]);
+    $assert(!is_wp_error($child_b), 'Could not create Child B.');
+    $test_term_ids[] = $child_b['term_id'];
+
+    $grandchild_a = wp_insert_term($term_names['grandchild_a'], 'category', ['parent' => $child_a['term_id']]);
+    $assert(!is_wp_error($grandchild_a), 'Could not create Grandchild A.');
+    $test_term_ids[] = $grandchild_a['term_id'];
+
+    $grandchild_b = wp_insert_term($term_names['grandchild_b'], 'category', ['parent' => $child_b['term_id']]);
+    $assert(!is_wp_error($grandchild_b), 'Could not create Grandchild B.');
+    $test_term_ids[] = $grandchild_b['term_id'];
+
+    $middle_term = get_term($middle['term_id'], 'category');
+    $assert($middle_term && !is_wp_error($middle_term), 'Could not load the restricted term.');
+
+    wp_set_current_user($test_user_id);
+    presspermit()->setUser($test_user_id);
+
+    $unrestricted_subset = get_terms([
+        'taxonomy' => 'category',
+        'get' => 'all',
+        'include' => [$middle['term_id']],
+        'required_operation' => 'assign',
+        'object_type' => 'post',
+    ]);
+    $assert(!is_wp_error($unrestricted_subset), 'The unrestricted control query failed.');
+    $assert(1 === count($unrestricted_subset), 'The unrestricted control query returned an unexpected number of terms.');
+    $assert(
+        (int) $top['term_id'] === (int) reset($unrestricted_subset)->parent,
+        'An unrestricted partial query was unexpectedly remapped.'
+    );
+
+    wp_set_current_user($original_user_id);
+    presspermit()->setUser($original_user_id);
+
+    \PublishPress\Permissions\API::assignExceptions(
+        [
+            'item' => [$test_user_id => true],
+            'children' => [$test_user_id => true],
+        ],
+        'user',
+        [
+            'operation' => 'assign',
+            'mod_type' => 'include',
+            'for_item_source' => 'post',
+            'for_item_type' => 'post',
+            'via_item_source' => 'term',
+            'via_item_type' => 'category',
+            'item_id' => $middle_term->term_taxonomy_id,
+        ]
+    );
+
+    wp_set_current_user($test_user_id);
+    presspermit()->setUser($test_user_id);
+
+    $terms = get_terms([
+        'taxonomy' => 'category',
+        'get' => 'all',
+        'required_operation' => 'assign',
+        'object_type' => 'post',
+    ]);
+    $assert(!is_wp_error($terms), 'The restricted term query failed.');
+
+    $terms_by_id = [];
+    foreach ($terms as $term) {
+        $terms_by_id[$term->term_id] = $term;
+    }
+
+    $assert(empty($terms_by_id[$top['term_id']]), 'The inaccessible ancestor was not filtered out.');
+    $assert(isset($terms_by_id[$middle['term_id']]), 'The restricted subtree root is missing.');
+    $assert(0 === (int) $terms_by_id[$middle['term_id']]->parent, 'The restricted subtree root was not remapped to level zero.');
+    $assert((int) $middle['term_id'] === (int) $terms_by_id[$child_a['term_id']]->parent, 'Child A was orphaned.');
+    $assert((int) $middle['term_id'] === (int) $terms_by_id[$child_b['term_id']]->parent, 'Child B was orphaned.');
+    $assert((int) $child_a['term_id'] === (int) $terms_by_id[$grandchild_a['term_id']]->parent, 'Grandchild A was orphaned.');
+    $assert((int) $child_b['term_id'] === (int) $terms_by_id[$grandchild_b['term_id']]->parent, 'Grandchild B was orphaned.');
+
+    $stored_middle = get_term($middle['term_id'], 'category');
+    $assert((int) $top['term_id'] === (int) $stored_middle->parent, 'The stored term parent was unexpectedly modified.');
+
+    require_once(ABSPATH . 'wp-admin/includes/template.php');
+    ob_start();
+    wp_terms_checklist(0, ['taxonomy' => 'category']);
+    $checklist = ob_get_clean();
+
+    $middle_position = strpos($checklist, esc_html($term_names['middle']));
+    $child_a_position = strpos($checklist, esc_html($term_names['child_a']));
+    $grandchild_a_position = strpos($checklist, esc_html($term_names['grandchild_a']));
+
+    $assert(false !== $middle_position, 'The restricted subtree root is missing from the checklist.');
+    $assert(false !== $child_a_position, 'Child A is missing from the checklist.');
+    $assert(false !== $grandchild_a_position, 'Grandchild A is missing from the checklist.');
+    $assert($middle_position < $child_a_position, 'The restricted subtree root is rendered after Child A.');
+    $assert($child_a_position < $grandchild_a_position, 'Grandchild A is not rendered beneath Child A.');
+} catch (Throwable $throwable) {
+    $failure = $throwable;
+} finally {
+    wp_set_current_user($original_user_id);
+    presspermit()->setUser($original_user_id);
+
+    if ($test_user_id && !is_wp_error($test_user_id)) {
+        \PublishPress\Permissions\API::deleteExceptions([$test_user_id], 'user');
+        require_once(ABSPATH . 'wp-admin/includes/user.php');
+        wp_delete_user($test_user_id);
+    }
+
+    foreach (array_reverse($test_term_ids) as $term_id) {
+        wp_delete_term($term_id, 'category');
+    }
+
+    if (null === $original_pagenow) {
+        unset($GLOBALS['pagenow']);
+    } else {
+        $pagenow = $original_pagenow;
+    }
+}
+
+if ($failure) {
+    fwrite(STDERR, 'FAIL: ' . $failure->getMessage() . "\n");
+    exit(1);
+}
+
+echo "PASS: Issue #2421 term checklist hierarchy is preserved.\n";


### PR DESCRIPTION
## Summary

- Preserve the hierarchy of nested Assign-Term restrictions in classic post-editor term checklists.
- Limit parent remapping to hierarchical `get=all` assign/manage queries that PublishPress Permissions actually filtered.
- Reuse the existing PressShack ancestry remapper instead of applying a global normalization rule.
- Add a self-cleaning integration regression test for the exact issue.
- Update the test build to 4.8.4-alpha.1.

## Root cause

`wp_terms_checklist()` requests `get=all`. WordPress converts that query to `hierarchical=false`, so the existing Permissions parent-remapping path was skipped after an inaccessible ancestor was removed. The category walker then had no valid root and rendered alphabetically sorted children as top-level terms.

## Testing

- Regression test passes on WordPress 7.1-beta3 with PHP 8.2.
- The same test fails at the expected parent-remapping assertion on unmodified `development`.
- Unrestricted partial term queries retain their original parent IDs.
- Stored term parents remain unchanged after checklist rendering.
- 255 PHP files pass syntax lint.
- Changed runtime files pass PublishPress PHPCS.
- Changed runtime files pass PHP 7.2 compatibility checks.
- Packaged ZIP passes integrity, single-root, version-consistency and runtime regression checks.

## Existing baseline findings

Full-package PHP compatibility and Plugin Check still report unrelated findings already present on `development`. This PR does not add findings in the changed hierarchy code.

Closes #2421
