### PR TITLE
Fix #1107: redirect after plugin activation

### DIFF
--- a/classes/PublishPress/Permissions/UI/Dashboard/DashboardFilters.php
+++ b/classes/PublishPress/Permissions/UI/Dashboard/DashboardFilters.php
@@ -17,6 +17,7 @@ class DashboardFilters
         do_action('_presspermit_admin_ui');
 
         // ============== UI-related filters ================
+        add_action('admin_init', [$this, 'actActivationRedirect']);
         add_action('admin_menu', [$this, 'actBuildMenu'], 21);
 
         add_action('show_user_profile', [$this, 'actUserUi'], 2);
@@ -154,6 +155,36 @@ class DashboardFilters
                 \PublishPress\Permissions\UI\AgentPermissionsUI::exceptionAssignmentScripts();
             }
         }
+    }
+
+    public function actActivationRedirect()
+    {
+        global $pagenow;
+
+        if (!get_option('presspermit_activation')) {
+            return;
+        }
+
+        delete_option('presspermit_activation');
+
+        if (!current_user_can('pp_manage_settings') || is_network_admin()) {
+            return;
+        }
+
+        if (wp_doing_ajax() || wp_doing_cron() || wp_is_json_request()) {
+            return;
+        }
+
+        if (!empty($_REQUEST['activate-multi']) || !empty($_REQUEST['action']) && ('error_scrape' === sanitize_key($_REQUEST['action']))) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+            return;
+        }
+
+        if ('admin.php' === $pagenow && 'presspermit-settings' === PWP::REQUEST_key('page')) {
+            return;
+        }
+
+        wp_safe_redirect(admin_url('admin.php?page=presspermit-settings'));
+        exit;
     }
 
     public function actReinstateSoloSubmenus()


### PR DESCRIPTION
## Summary
- redirect administrators to `Permissions > Settings` after activation
- avoid redirecting for network admin, AJAX/cron/json requests, bulk activation, and error scrape flows
- clear the one-time activation flag before redirecting

## Testing
- `php -l classes/PublishPress/Permissions/UI/Dashboard/DashboardFilters.php`
- verified in the local WordPress playground that activating the plugin leads to `admin.php?page=presspermit-settings` on the next admin request