### PR TITLE
Fix #1324: clarify Term (Manage) description

### DIFF
--- a/classes/PublishPress/Permissions/UI/AgentExceptionsAjax.php
+++ b/classes/PublishPress/Permissions/UI/AgentExceptionsAjax.php
@@ -98,7 +98,7 @@ class AgentExceptionsAjax
                 if ($for_type === '_term_') {
                     $tooltips = [
                         'associate' => esc_html__('Control which terms can be set as a Parent of other terms.', 'press-permit-core'),
-                        'manage'    => esc_html__('Allow users to manage selected terms.', 'press-permit-core'),
+                        'manage'    => esc_html__('Enable or block the ability to edit a term or select it as the Parent or another term.', 'press-permit-core'),
                     ];
                 } elseif ($for_source_name === 'pp_group') {
                     $tooltips = [


### PR DESCRIPTION
## Summary
- update the Term management tooltip copy on the Edit Permissions screen
- make the `_term_` management action explain that it edits a term or uses it as a parent/related term

## Testing
- `composer check:phpcs -- classes/PublishPress/Permissions/UI/AgentExceptionsAjax.php`
- verified the AJAX response in the local WordPress playground returns the updated tooltip text for `_term_` management