### PR TITLE
Remove presspermit-collaboration module from deactivated modules

### DIFF
--- a/classes/PublishPress/Permissions/PluginUpdated.php
+++ b/classes/PublishPress/Permissions/PluginUpdated.php
@@ -26,6 +26,13 @@ class PluginUpdated
             // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
             $wpdb->query("DELETE FROM $wpdb->options WHERE option_name LIKE 'buffer_metagroup_id_%'");
 
+            $deactivated_modules = (array) get_option('presspermit_deactivated_modules');
+            $required_modules = array_intersect_key($deactivated_modules, array_fill_keys(presspermit()->getRequiredModules(), true));
+            if ($required_modules) {
+                $deactivated_modules = array_diff_key($deactivated_modules, $required_modules);
+                update_option('presspermit_deactivated_modules', $deactivated_modules);
+            }
+
             if (version_compare($prev_version, '2.7-beta', '>=')
             && version_compare($prev_version, '2.7-beta3', '<')
             ) {


### PR DESCRIPTION
## Summary
- stop treating the collaboration module as a disableable feature
- hide the Editing Permissions toggle from the Features screen
- ignore stored deactivation for the collaboration module and clean it up on update/save

Fixes:
- #2417

## Testing
- `composer check:phpcs -- classes/PublishPress/Permissions.php classes/PublishPress/Permissions/PluginUpdated.php classes/PublishPress/Permissions/UI/Handlers/Settings.php classes/PublishPress/Permissions/UI/SettingsTabModules.php`
- verified in the local WordPress playground that the Features tab no longer shows an Editing Permissions toggle