### PR TITLE
Disable "Permission Group" by default

### DIFF
--- a/classes/PublishPress/Permissions.php
+++ b/classes/PublishPress/Permissions.php
@@ -242,6 +242,7 @@ class Permissions
         $this->default_options = [
             'enabled_taxonomies' => ['category' => true, 'post_tag' => true],
             'enabled_post_types' => array_fill_keys(['post', 'page'], true),
+            'display_group_exceptions' => 0,
             'define_media_post_caps' => 0,
             'define_create_posts_cap' => 0,
             'strip_private_caption' => 1,

--- a/classes/PublishPress/Permissions/PluginUpdated.php
+++ b/classes/PublishPress/Permissions/PluginUpdated.php
@@ -33,6 +33,14 @@ class PluginUpdated
                 update_option('presspermit_deactivated_modules', $deactivated_modules);
             }
 
+            if (!get_option('presspermit_display_group_exceptions')) {
+                // Preserve visibility for sites that already manage Permission Groups via Specific Permissions.
+                // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
+                if ($wpdb->get_var("SELECT exception_id FROM $wpdb->ppc_exceptions WHERE for_item_source = 'pp_group' LIMIT 1")) {
+                    update_option('presspermit_display_group_exceptions', 1);
+                }
+            }
+
             if (version_compare($prev_version, '2.7-beta', '>=')
             && version_compare($prev_version, '2.7-beta3', '<')
             ) {

--- a/classes/PublishPress/Permissions/UI/AgentPermissionsUI.php
+++ b/classes/PublishPress/Permissions/UI/AgentPermissionsUI.php
@@ -91,6 +91,8 @@ class AgentPermissionsUI
             return;
         }
 
+        $type_objects = self::filterExceptionTypeObjects($type_objects);
+
         echo "<option class='pp-opt-none' value=''>" . esc_html__('select...', 'press-permit-core') . '</option>';
 
         foreach ($type_objects as $_type => $type_obj) {
@@ -114,6 +116,15 @@ class AgentPermissionsUI
                 echo "<option value='-1'>" . esc_html__('n/a', 'press-permit-core') . '</option>';
             }
         }
+    }
+
+    private static function filterExceptionTypeObjects($type_objects)
+    {
+        if (!presspermit()->getOption('display_group_exceptions')) {
+            unset($type_objects['pp_group'], $type_objects['pp_net_group']);
+        }
+
+        return $type_objects;
     }
 
     private static function selectExceptionsUi($type_objects, $taxonomy_objects, $args = [])
@@ -298,6 +309,8 @@ class AgentPermissionsUI
 
             private static function itemSelectUI($type_objects)
             {
+                $type_objects = self::filterExceptionTypeObjects($type_objects);
+
                 require_once(PRESSPERMIT_CLASSPATH . '/UI/ItemsMetabox.php');
 
                 add_filter('get_terms_args', [__CLASS__, 'fltTermSelectNoPaging'], 50, 2);

--- a/classes/PublishPress/Permissions/UI/SettingsAdmin.php
+++ b/classes/PublishPress/Permissions/UI/SettingsAdmin.php
@@ -86,6 +86,9 @@ class SettingsAdmin
         case 'display_user_profile_roles' :
         return __('Note: Groups and Roles are always displayed on the Edit User screen.', 'press-permit-core');
 
+        case 'display_group_exceptions' :
+        return __('Show Permission Groups as a Specific Permissions content type on the Edit Permissions screen.', 'press-permit-core');
+
 
         // Advanced
         case 'anonymous_unfiltered' :

--- a/classes/PublishPress/Permissions/UI/SettingsTabAdvanced.php
+++ b/classes/PublishPress/Permissions/UI/SettingsTabAdvanced.php
@@ -70,6 +70,7 @@ class SettingsTabAdvanced
             'list_others_uneditable_posts'           => esc_html__('List other user\'s uneditable posts', 'press-permit-core'),
             'lock_top_pages'                         => esc_html__('Pages can be set or removed from Top Level by: ', 'press-permit-core'),
             'create_tag_require_edit_cap'            => esc_html__('Tag creation requires Tag edit capability', 'press-permit-core'),
+            'display_group_exceptions'               => esc_html__('Permission Groups in Edit Permissions', 'press-permit-core'),
         ];
 
         // Settings that are displayed if already set to a non-default value, or if "Display all" is enabled
@@ -165,7 +166,7 @@ class SettingsTabAdvanced
             $additional = [
                 'post_editor'         => ['lock_top_pages', 'page_parent_order', 'page_parent_editable_only', 'auto_assign_available_term', 'create_tag_require_edit_cap', 'use_tabbed_metabox'],
                 'permissions'         => ['post_blockage_priority', 'suppress_administrator_metagroups', 'publish_exceptions', 'non_admins_set_read_exceptions', 'non_admins_set_edit_exceptions'],
-                'user_management'     => ['new_user_groups_ui', 'display_user_profile_groups', 'display_user_profile_roles', 'users_bulk_groups', 'add_author_pages', 'publish_author_pages', 'limit_user_edit_enabled', 'limit_user_edit_by_level', 'user_permissions'],
+                'user_management'     => ['new_user_groups_ui', 'display_user_profile_groups', 'display_user_profile_roles', 'display_group_exceptions', 'users_bulk_groups', 'add_author_pages', 'publish_author_pages', 'limit_user_edit_enabled', 'limit_user_edit_by_level', 'user_permissions'],
                 'front_end'           => ['media_search_results', 'anonymous_unfiltered', 'regulate_category_archive_page', 'limit_front_end_term_filtering', 'term_counts_unfiltered', 'strip_private_caption', 'force_nav_menu_filter'],
                 'role_integration'    => ['pattern_roles_include_generic_rolecaps', 'dynamic_wp_roles'],
                 'nav_menu_management' => ['admin_nav_menu_partial_editing', 'admin_nav_menu_lock_custom'],
@@ -476,6 +477,7 @@ class SettingsTabAdvanced
                     $hint = SettingsAdmin::getStr('display_user_profile_roles');
                     $ui->optionCheckbox('display_user_profile_groups', $tab, $section);
                     $ui->optionCheckbox('display_user_profile_roles', $tab, $section, $hint);
+                    $ui->optionCheckbox('display_group_exceptions', $tab, $section, true);
 
                     $ui->optionCheckbox('user_search_by_role', $tab, $section, true);
 


### PR DESCRIPTION
## Summary
- hide Permission Groups from the Edit Permissions type selector by default
- add an Advanced setting to re-enable Permission Groups in Edit Permissions when needed
- preserve visibility automatically on updates for sites that already have Permission Group exceptions stored

## Testing
- verified in the local WordPress playground that the Edit Permissions selector hides Permission Groups by default
- verified the new `Permission Groups in Edit Permissions` setting renders in the Advanced tab
- `composer check:phpcs -- classes/PublishPress/Permissions.php classes/PublishPress/Permissions/PluginUpdated.php classes/PublishPress/Permissions/UI/AgentPermissionsUI.php classes/PublishPress/Permissions/UI/SettingsAdmin.php classes/PublishPress/Permissions/UI/SettingsTabAdvanced.php`