### PR TITLE
Fix Security issue with IDOR method on REST comment read permissions

### DIFF
--- a/classes/PublishPress/Permissions/CommentFilters.php
+++ b/classes/PublishPress/Permissions/CommentFilters.php
@@ -6,6 +6,7 @@ class CommentFilters
 {
     public function __construct() {
         add_filter('comments_clauses', [$this, 'fltCommentsClauses'], 10, 2);
+        add_filter('comment_feed_where', [$this, 'fltCommentFeedWhere']);
     }
 
     public function fltCommentsClauses($clauses, $qry_obj = false, $args = [])
@@ -66,5 +67,24 @@ class CommentFilters
         }
 
         return $clauses;
+    }
+
+    public function fltCommentFeedWhere($where)
+    {
+        global $wpdb;
+
+        $query_contexts = ['comments'];
+
+        $where = preg_replace("/ post_status\s*=\s*[']?publish[']?/", " {$wpdb->posts}.post_status = 'publish'", $where);
+
+        $where = preg_replace('/^\s*WHERE\s+/i', '', $where);
+
+        $where = apply_filters(
+            'presspermit_posts_where',
+            'AND ' . $where,
+            ['skip_teaser' => true, 'query_contexts' => $query_contexts]
+        );
+
+        return preg_replace('/^\s*AND\s+/i', 'WHERE ', $where, 1);
     }
 }

--- a/classes/PublishPress/Permissions/CommentFilters.php
+++ b/classes/PublishPress/Permissions/CommentFilters.php
@@ -6,7 +6,8 @@ class CommentFilters
 {
     public function __construct() {
         add_filter('comments_clauses', [$this, 'fltCommentsClauses'], 10, 2);
-        add_filter('comment_feed_where', [$this, 'fltCommentFeedWhere']);
+        add_filter('comment_feed_join', [$this, 'fltCommentFeedJoin'], 10, 2);
+        add_filter('comment_feed_where', [$this, 'fltCommentFeedWhere'], 10, 2);
         add_filter('comments_array', [$this, 'fltCommentResults'], 99);
         add_filter('the_comments', [$this, 'fltCommentResults'], 99);
     }
@@ -114,6 +115,17 @@ class CommentFilters
         );
 
         return "WHERE 1=1 $pp_where AND $where";
+    }
+
+    public function fltCommentFeedJoin($join, $query_obj = false)
+    {
+        global $wpdb;
+
+        if (false === strpos($join, $wpdb->posts)) {
+            $join .= " JOIN {$wpdb->posts} ON ( {$wpdb->comments}.comment_post_ID = {$wpdb->posts}.ID )";
+        }
+
+        return $join;
     }
 
     public function fltCommentResults($comments)

--- a/classes/PublishPress/Permissions/CommentFilters.php
+++ b/classes/PublishPress/Permissions/CommentFilters.php
@@ -71,33 +71,100 @@ class CommentFilters
         return $clauses;
     }
 
-    public function fltCommentFeedWhere($where)
+    public function fltCommentFeedWhere($where, $query_obj = false)
     {
         global $wpdb;
 
         $query_contexts = ['comments'];
 
+        $post_type = '';
+        $post_id = ($query_obj && !empty($query_obj->query_vars['p'])) ? (int) $query_obj->query_vars['p'] : 0;
+
+        if ($post_id) {
+            if ($_post = get_post($post_id)) {
+                $post_type = $_post->post_type;
+            }
+        } else {
+            $post_type = ($query_obj && !empty($query_obj->query_vars['post_type'])) ? $query_obj->query_vars['post_type'] : '';
+        }
+
+        if ($post_type && !in_array($post_type, presspermit()->getEnabledPostTypes(), true)) {
+            return $where;
+        }
+
         $where = preg_replace("/ post_status\s*=\s*[']?publish[']?/", " {$wpdb->posts}.post_status = 'publish'", $where);
 
         $where = preg_replace('/^\s*WHERE\s+/i', '', $where);
 
-        $where = apply_filters(
-            'presspermit_posts_where',
-            'AND ' . $where,
-            ['skip_teaser' => true, 'query_contexts' => $query_contexts]
+        if (!class_exists('\PublishPress\Permissions\PostFilters')) {
+            require_once(PRESSPERMIT_CLASSPATH . '/PostFilters.php');
+        }
+
+        $feed_post_types = ($post_type) ? [$post_type] : presspermit()->getEnabledPostTypes();
+
+        $pp_where = PostFilters::instance()->getPostsWhere(
+            [
+                'post_types' => $feed_post_types,
+                'required_operation' => 'read',
+                'skip_teaser' => true,
+                'query_contexts' => $query_contexts,
+                'query_vars' => ($query_obj && !empty($query_obj->query_vars)) ? $query_obj->query_vars : [],
+                'src_table' => $wpdb->posts,
+            ]
         );
 
-        return preg_replace('/^\s*AND\s+/i', 'WHERE ', $where, 1);
+        return "WHERE 1=1 $pp_where AND $where";
     }
 
     public function fltCommentResults($comments)
     {
         foreach (array_keys((array) $comments) as $key) {
-            if (!empty($comments[$key]->comment_post_ID) && !current_user_can('read_post', $comments[$key]->comment_post_ID)) {
+            if (!empty($comments[$key]->comment_post_ID) && !$this->isCommentPostReadable((int) $comments[$key]->comment_post_ID)) {
                 unset($comments[$key]);
             }
         }
 
         return $comments;
+    }
+
+    private function isCommentPostReadable($post_id)
+    {
+        static $readable = [];
+
+        if (isset($readable[$post_id])) {
+            return $readable[$post_id];
+        }
+
+        $post_type = get_post_field('post_type', $post_id);
+
+        if (!$post_type || !in_array($post_type, presspermit()->getEnabledPostTypes(), true)) {
+            return $readable[$post_id] = true;
+        }
+
+        if (!class_exists('\PublishPress\Permissions\PostFilters')) {
+            require_once(PRESSPERMIT_CLASSPATH . '/PostFilters.php');
+        }
+
+        global $wpdb;
+
+        $where = PostFilters::instance()->getPostsWhere(
+            [
+                'post_types' => $post_type,
+                'required_operation' => 'read',
+                'skip_teaser' => true,
+                'query_contexts' => ['comments'],
+                'src_table' => $wpdb->posts,
+            ]
+        );
+
+        // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
+        $result = $wpdb->get_var(
+            $wpdb->prepare(
+                "SELECT {$wpdb->posts}.ID FROM {$wpdb->posts} WHERE {$wpdb->posts}.ID = %d $where LIMIT 1", // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+                $post_id
+            )
+        );
+
+        return $readable[$post_id] = !empty($result);
     }
 }

--- a/classes/PublishPress/Permissions/CommentFilters.php
+++ b/classes/PublishPress/Permissions/CommentFilters.php
@@ -7,6 +7,8 @@ class CommentFilters
     public function __construct() {
         add_filter('comments_clauses', [$this, 'fltCommentsClauses'], 10, 2);
         add_filter('comment_feed_where', [$this, 'fltCommentFeedWhere']);
+        add_filter('comments_array', [$this, 'fltCommentResults'], 99);
+        add_filter('the_comments', [$this, 'fltCommentResults'], 99);
     }
 
     public function fltCommentsClauses($clauses, $qry_obj = false, $args = [])
@@ -86,5 +88,16 @@ class CommentFilters
         );
 
         return preg_replace('/^\s*AND\s+/i', 'WHERE ', $where, 1);
+    }
+
+    public function fltCommentResults($comments)
+    {
+        foreach (array_keys((array) $comments) as $key) {
+            if (!empty($comments[$key]->comment_post_ID) && !current_user_can('read_post', $comments[$key]->comment_post_ID)) {
+                unset($comments[$key]);
+            }
+        }
+
+        return $comments;
     }
 }

--- a/classes/PublishPress/Permissions/CommentFiltersAdministrator.php
+++ b/classes/PublishPress/Permissions/CommentFiltersAdministrator.php
@@ -6,6 +6,7 @@ class CommentFiltersAdministrator
 {
     public function __construct() {
         add_filter('comments_clauses', [$this, 'fltCommentsClauses']);
+        add_filter('comment_feed_where', [$this, 'fltCommentFeedWhere']);
     }
 
     public function fltCommentsClauses($clauses)
@@ -25,5 +26,24 @@ class CommentFiltersAdministrator
         );
 
         return $clauses;
+    }
+
+    public function fltCommentFeedWhere($where)
+    {
+        global $wpdb;
+
+        $stati = get_post_stati(['public' => true, 'private' => true], 'names', 'or');
+
+        if (!defined('PP_NO_ATTACHMENT_COMMENTS')) {
+            $stati[] = 'inherit';
+        }
+
+        $status_csv = "'" . implode("','", array_map('sanitize_key', $stati)) . "'";
+
+        return preg_replace(
+            "/\s*AND\s*post_status\s*=\s*[']?publish[']?/",
+            " AND {$wpdb->posts}.post_status IN ($status_csv)",
+            $where
+        );
     }
 }

--- a/classes/PublishPress/Permissions/CommentFiltersAdministrator.php
+++ b/classes/PublishPress/Permissions/CommentFiltersAdministrator.php
@@ -6,7 +6,8 @@ class CommentFiltersAdministrator
 {
     public function __construct() {
         add_filter('comments_clauses', [$this, 'fltCommentsClauses']);
-        add_filter('comment_feed_where', [$this, 'fltCommentFeedWhere']);
+        add_filter('comment_feed_join', [$this, 'fltCommentFeedJoin'], 10, 2);
+        add_filter('comment_feed_where', [$this, 'fltCommentFeedWhere'], 10, 2);
     }
 
     public function fltCommentsClauses($clauses)
@@ -45,5 +46,16 @@ class CommentFiltersAdministrator
             " AND {$wpdb->posts}.post_status IN ($status_csv)",
             $where
         );
+    }
+
+    public function fltCommentFeedJoin($join, $query_obj = false)
+    {
+        global $wpdb;
+
+        if (false === strpos($join, $wpdb->posts)) {
+            $join .= " JOIN {$wpdb->posts} ON ( {$wpdb->comments}.comment_post_ID = {$wpdb->posts}.ID )";
+        }
+
+        return $join;
     }
 }

--- a/classes/PublishPress/Permissions/REST.php
+++ b/classes/PublishPress/Permissions/REST.php
@@ -1,6 +1,8 @@
 <?php
 namespace PublishPress\Permissions;
 
+require_once(PRESSPERMIT_CLASSPATH . '/RESTHelper.php');
+
 class REST
 {
     var $route = '';
@@ -126,6 +128,8 @@ class REST
                     continue;
                 }
 
+                $this->is_view_method = in_array($method, [\WP_REST_Server::READABLE, 'GET']);
+
                 if (is_object($handler['callback'][0])) {
 					$this->endpoint_class = get_class($handler['callback'][0]);
 
@@ -137,12 +141,18 @@ class REST
 				
                 if (!in_array($this->endpoint_class, $post_endpoints, true) && !in_array($this->endpoint_class, $term_endpoints, true)
                 ) {
-                    continue;
+                    if ('WP_REST_Comments_Controller' == $this->endpoint_class) {
+                        if ($this->is_view_method && ($comment_denied = RESTHelper::confirmCommentReadable($request))) {
+                            return $comment_denied;
+                        }
+
+                    } else {
+                        continue;
+                    }
                 }
 				
                 $this->route = $route;
 
-                $this->is_view_method = in_array($method, [\WP_REST_Server::READABLE, 'GET']);
                 $this->params = $request->get_params();
                 
                 $headers = $request->get_headers();

--- a/classes/PublishPress/Permissions/REST.php
+++ b/classes/PublishPress/Permissions/REST.php
@@ -32,6 +32,10 @@ class REST
     {
         add_filter('presspermit_rest_post_cap_requirement', [$this, 'fltRestPostCapRequirement'], 10, 2);
         add_filter('rest_attachment_query', [$this, 'fltRestAttachmentQuery'], 10, 2);
+
+        foreach (get_taxonomies(['show_in_rest' => true], 'names') as $taxonomy) {
+            add_filter("rest_{$taxonomy}_query", [$this, 'fltRestTermQuery'], 10, 2);
+        }
     }
 
     public static function getPostType()
@@ -277,7 +281,7 @@ class REST
                         }
                     }
 
-                } elseif (in_array($this->endpoint_class, $term_endpoints)) { 
+                } elseif ($this->isRestController($handler['callback'][0], $term_endpoints)) { 
                     if (!empty($this->referer) && strpos($this->referer, 'post-new.php') && !empty($this->endpoint_class) && ('WP_REST_Terms_Controller' == $this->endpoint_class)) {
                         $this->operation = 'assign';
                         $this->is_view_method = false;
@@ -289,13 +293,17 @@ class REST
                     
                     $this->is_terms_request = true;
 
-                    if (empty($args['taxonomy'])) break;
+                    if (!empty($args['taxonomy'])) {
+                        $this->taxonomy = $args['taxonomy'];
+                    } elseif (is_object($handler['callback'][0]) && !empty($handler['callback'][0]->taxonomy)) {
+                        $this->taxonomy = $handler['callback'][0]->taxonomy;
+                    }
 
-                    $this->taxonomy = $args['taxonomy'];
+                    if (empty($this->taxonomy)) break;
 
                     if (!presspermit()->isContentAdministrator()) {
-                        if (!empty($args['post'])) {
-                            $post_id = $this->params['post'];
+                        if (!empty($this->params['post'])) {
+                            $post_id = (int) $this->params['post'];
 
                             $check_cap = ('read' == $required_operation) ? 'read_post' : 'edit_post';
 
@@ -304,13 +312,13 @@ class REST
                             }
                         }
 
-                        if (!empty($params['id'])) {
+                        if (!empty($this->params['id'])) {
                             $user_terms = get_terms(
                                 $this->taxonomy, 
                                 ['required_operation' => $required_operation, 'hide_empty' => 0, 'fields' => 'ids']
                             );
 
-                            if (!in_array($params['id'], $user_terms)) {
+                            if (!in_array((int) $this->params['id'], array_map('intval', (array) $user_terms), true)) {
                                 return self::rest_denied();
                             }
                         }
@@ -385,6 +393,22 @@ class REST
             if (!$args['post_parent__in']) {
                 $args['post_parent__in'] = [0];
             }
+        }
+
+        return $args;
+    }
+
+    public function fltRestTermQuery($args, $request)
+    {
+        if (!in_array($request->get_method(), [\WP_REST_Server::READABLE, 'GET'], true) || presspermit()->isContentAdministrator()) {
+            return $args;
+        }
+
+        $post_id = (int) $request->get_param('post');
+
+        if ($post_id && !current_user_can('read_post', $post_id)) {
+            $args['post'] = 0;
+            $args['object_ids'] = [0];
         }
 
         return $args;

--- a/classes/PublishPress/Permissions/REST.php
+++ b/classes/PublishPress/Permissions/REST.php
@@ -166,9 +166,14 @@ class REST
                     $this->operation = 'read';
                 }
 
-			  // voluntary filtering of get_items (for WYSIWY can edit, etc.)
-                if ($this->is_view_method && ('read' == $this->operation) && !PWP::empty_REQUEST('operation')) {
-                    $this->operation = PWP::REQUEST_key('operation');
+                // Allow authenticated clients to narrow a readable REST request to edit/delete checks,
+                // but never let a public request widen the derived read operation.
+                if ($this->is_view_method && ('read' == $this->operation) && is_user_logged_in() && !PWP::empty_REQUEST('operation')) {
+                    $requested_operation = PWP::REQUEST_key('operation');
+
+                    if (in_array($requested_operation, ['read', 'edit', 'delete'], true)) {
+                        $this->operation = $requested_operation;
+                    }
                 }
 			
                 // NOTE: setting or default may be adapted downstream
@@ -230,9 +235,17 @@ class REST
                     if (!presspermit()->isContentAdministrator()) {
                         // do this here because WP does not trigger a capability check if the post type is public
                         if ($this->post_id && in_array($this->post_type, presspermit()->getEnabledPostTypes(), true)) {
+                            $post_status = get_post_field('post_status', $this->post_id);
+                            $post_status_obj = get_post_status_object($post_status);
+
+                            // For view-method requests on public posts, always enforce PP's read gate even if
+                            // the caller supplied another operation hint.
+                            if ($this->is_view_method && !empty($post_status_obj->public) && !current_user_can('read_post', $this->post_id)) {
+                                return self::rest_denied();
+                            }
+
                             if ('read' == $this->operation) {
-                                $post_status_obj = get_post_status_object(get_post_field('post_status', $this->post_id));
-                                $check_cap = ($post_status_obj->public) ? 'read_post' : '';
+                                $check_cap = (!empty($post_status_obj->public)) ? 'read_post' : '';
 
                             } elseif(in_array($this->operation, ['edit','delete'], true)) {
                                 $check_cap = "{$this->operation}_post";
@@ -241,7 +254,7 @@ class REST
                             }
 
                             if ($check_cap && ! current_user_can($check_cap, $this->post_id) 
-                            && (('edit' != $this->operation) || ('trash' != get_post_field('post_status', $this->post_id)))
+                            && (('edit' != $this->operation) || ('trash' != $post_status))
                             ) { // Avoid conflicts with WP trashing. WP will still prevent editing of trashed posts
                                 return self::rest_denied();
                             }

--- a/classes/PublishPress/Permissions/REST.php
+++ b/classes/PublishPress/Permissions/REST.php
@@ -31,6 +31,7 @@ class REST
     private function __construct()
     {
         add_filter('presspermit_rest_post_cap_requirement', [$this, 'fltRestPostCapRequirement'], 10, 2);
+        add_filter('rest_attachment_query', [$this, 'fltRestAttachmentQuery'], 10, 2);
     }
 
     public static function getPostType()
@@ -71,6 +72,15 @@ class REST
         
         $extra_route_endpoints = array_replace($post_endpoints, $term_endpoints);
         $endpoint_post_types = [];
+
+        foreach (presspermit()->getEnabledPostTypes(['show_in_rest' => true], 'object') as $type_obj) {
+            if (!empty($type_obj->rest_controller_class)) {
+                $post_endpoints[] = $type_obj->rest_controller_class;
+                $endpoint_post_types[$type_obj->rest_controller_class] = $type_obj->name;
+            }
+        }
+
+        $endpoint_post_types['WP_REST_Attachments_Controller'] = 'attachment';
 		
         foreach($extra_route_endpoints as $route => $endpoint) {
             if ($route && !is_numeric($route)) {
@@ -106,6 +116,7 @@ class REST
         }
 
         $post_endpoints[]= 'WP_REST_Posts_Controller';
+        $post_endpoints[]= 'WP_REST_Attachments_Controller';
         $post_endpoints[]= 'WP_REST_Autosaves_Controller';
         $term_endpoints[]= 'WP_REST_Terms_Controller';
 		
@@ -139,7 +150,7 @@ class REST
                     continue;
                 }
 				
-                if (!in_array($this->endpoint_class, $post_endpoints, true) && !in_array($this->endpoint_class, $term_endpoints, true)
+                if (!$this->isRestController($handler['callback'][0], $post_endpoints) && !$this->isRestController($handler['callback'][0], $term_endpoints)
                 ) {
                     if ('WP_REST_Comments_Controller' == $this->endpoint_class) {
                         if ($this->is_view_method && ($comment_denied = RESTHelper::confirmCommentReadable($request))) {
@@ -185,7 +196,7 @@ class REST
                     }
                 }
 
-                if (in_array($this->endpoint_class, $post_endpoints)) {
+                if ($this->isRestController($handler['callback'][0], $post_endpoints)) {
                     $this->post_type = (!empty($args['post_type'])) ? $args['post_type'] : '';
                     
                     if (!$this->post_type && !empty($endpoint_post_types[$this->endpoint_class])) {
@@ -234,13 +245,18 @@ class REST
 
                     if (!presspermit()->isContentAdministrator()) {
                         // do this here because WP does not trigger a capability check if the post type is public
-                        if ($this->post_id && in_array($this->post_type, presspermit()->getEnabledPostTypes(), true)) {
+                        if ($this->post_id && (('attachment' == $this->post_type) || in_array($this->post_type, presspermit()->getEnabledPostTypes(), true))) {
                             $post_status = get_post_field('post_status', $this->post_id);
                             $post_status_obj = get_post_status_object($post_status);
+                            $parent_id = ('attachment' == $this->post_type) ? (int) get_post_field('post_parent', $this->post_id) : 0;
 
-                            // For view-method requests on public posts, always enforce PP's read gate even if
-                            // the caller supplied another operation hint.
-                            if ($this->is_view_method && !empty($post_status_obj->public) && !current_user_can('read_post', $this->post_id)) {
+                            // For any view-method request on a resolved item, always enforce PP's read gate
+                            // even if the caller supplied another operation hint or the controller is not the
+                            // default posts controller (e.g. attachments / custom REST controllers).
+                            if ($this->is_view_method && (
+                                !current_user_can('read_post', $this->post_id)
+                                || ($parent_id && !current_user_can('read_post', $parent_id))
+                            )) {
                                 return self::rest_denied();
                             }
 
@@ -326,5 +342,66 @@ class REST
     function fltRestPostID($post_id)
     {
         return ($this->post_id) ? $this->post_id : $post_id;
+    }
+
+    public function fltRestAttachmentQuery($args, $request)
+    {
+        if (!in_array($request->get_method(), [\WP_REST_Server::READABLE, 'GET'], true) || presspermit()->isContentAdministrator()) {
+            return $args;
+        }
+
+        if (!class_exists('\PublishPress\Permissions\PostFilters')) {
+            require_once(PRESSPERMIT_CLASSPATH . '/PostFilters.php');
+        }
+
+        global $wpdb;
+
+        $join = PostFilters::instance()->fltPostsJoin('', ['context' => 'rest_attachment_query']);
+        $where = PostFilters::instance()->getPostsWhere(
+            [
+                'post_types' => ['attachment'],
+                'required_operation' => 'read',
+                'force_types' => true,
+                'src_table' => $wpdb->posts,
+                'join' => $join,
+            ]
+        );
+
+        // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
+        $readable_ids = $wpdb->get_col(
+            "SELECT {$wpdb->posts}.ID FROM {$wpdb->posts} $join WHERE {$wpdb->posts}.post_type = 'attachment' $where" // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+        );
+
+        $args['post__in'] = $readable_ids ? array_map('intval', $readable_ids) : [0];
+
+        if (!empty($args['post_parent__in'])) {
+            $args['post_parent__in'] = array_values(
+                array_intersect(
+                    array_map('intval', (array) $args['post_parent__in']),
+                    array_map('intval', wp_list_pluck((array) get_posts(['post_type' => 'attachment', 'post__in' => $args['post__in'], 'posts_per_page' => -1]), 'post_parent'))
+                )
+            );
+
+            if (!$args['post_parent__in']) {
+                $args['post_parent__in'] = [0];
+            }
+        }
+
+        return $args;
+    }
+
+    private function isRestController($controller, $allowed_classes)
+    {
+        foreach ((array) $allowed_classes as $allowed_class) {
+            if (is_object($controller) && is_a($controller, $allowed_class)) {
+                return true;
+            }
+
+            if (is_string($controller) && ($controller === $allowed_class || is_subclass_of($controller, $allowed_class))) {
+                return true;
+            }
+        }
+
+        return false;
     }
 }

--- a/classes/PublishPress/Permissions/RESTHelper.php
+++ b/classes/PublishPress/Permissions/RESTHelper.php
@@ -4,13 +4,48 @@ namespace PublishPress\Permissions;
 
 class RESTHelper
 {
+    public static function restForbidden()
+    {
+        return new \WP_Error('rest_forbidden', esc_html__("Sorry, you are not allowed to do that."), ['status' => 403]);
+    }
+
+    public static function getRequestItemId($request)
+    {
+        $item_id = $request->get_param('id');
+
+        if (!$item_id) {
+            $arr_path = explode('/', trim($request->get_route(), '/'));
+            $item_id = array_pop($arr_path);
+        }
+
+        return (is_numeric($item_id)) ? (int) $item_id : 0;
+    }
+
+    public static function confirmCommentReadable($request)
+    {
+        if (!$comment_id = self::getRequestItemId($request)) {
+            return null;
+        }
+
+        if (!$comment = get_comment($comment_id)) {
+            return null;
+        }
+
+        if ($comment->comment_post_ID && !current_user_can('read_post', $comment->comment_post_ID)) {
+            return self::restForbidden();
+        }
+
+        return null;
+    }
+
     // As of 4.8, WP does not trigger a REST capability check for viewing single public posts
     public static function fltConfirmRestReadable($rest_response, $handler, $request)
     {
         $pp = presspermit();
+        $is_readable_request = !is_wp_error($rest_response) && in_array($request->get_method(), [\WP_REST_Server::READABLE, 'GET'], true);
 
         // we are only concerned about read access here
-        if (!is_wp_error($rest_response) && in_array($request->get_method(), [\WP_REST_Server::READABLE, 'GET'], true)) {
+        if ($is_readable_request) {
             $controller_class = get_class($handler['callback'][0]);
 
             if ('WP_REST_Posts_Controller' == $controller_class) {
@@ -41,6 +76,12 @@ class RESTHelper
                         }
                     }
                 }
+            }
+        }
+
+        if ($is_readable_request && !empty($handler['callback'][0]) && is_object($handler['callback'][0]) && ('WP_REST_Comments_Controller' == get_class($handler['callback'][0]))) {
+            if ($comment_denied = self::confirmCommentReadable($request)) {
+                return $comment_denied;
             }
         }
 

--- a/classes/PublishPress/Permissions/RESTLegacy.php
+++ b/classes/PublishPress/Permissions/RESTLegacy.php
@@ -10,6 +10,8 @@ class RESTLegacy
         if (!is_wp_error($rest_response) && !in_array($request->get_method(), [\WP_REST_Server::READABLE, 'GET'], true))
             return $rest_response;
 
+        require_once(PRESSPERMIT_CLASSPATH . '/RESTHelper.php');
+
         $pp = presspermit();
 
         $path = $request->get_route();
@@ -35,6 +37,11 @@ class RESTLegacy
                                         }
                                     }
                                 }
+                            }
+
+                        } elseif ('WP_REST_Comments_Controller' == get_class($handler['callback'][0])) {
+                            if ($comment_denied = RESTHelper::confirmCommentReadable($request)) {
+                                return $comment_denied;
                             }
                         }
                     }

--- a/composer.lock
+++ b/composer.lock
@@ -659,16 +659,16 @@
         },
         {
             "name": "friendsofphp/php-cs-fixer",
-            "version": "v3.95.20",
+            "version": "v3.95.23",
             "source": {
                 "type": "git",
                 "url": "https://github.com/PHP-CS-Fixer/PHP-CS-Fixer.git",
-                "reference": "4d6c9886a77dbc1db3b9eaca6472cedf9eb1fab7"
+                "reference": "b2932a5af3157a0c28324b1efe5e3b556dee09c4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PHP-CS-Fixer/PHP-CS-Fixer/zipball/4d6c9886a77dbc1db3b9eaca6472cedf9eb1fab7",
-                "reference": "4d6c9886a77dbc1db3b9eaca6472cedf9eb1fab7",
+                "url": "https://api.github.com/repos/PHP-CS-Fixer/PHP-CS-Fixer/zipball/b2932a5af3157a0c28324b1efe5e3b556dee09c4",
+                "reference": "b2932a5af3157a0c28324b1efe5e3b556dee09c4",
                 "shasum": ""
             },
             "require": {
@@ -751,7 +751,7 @@
             ],
             "support": {
                 "issues": "https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/issues",
-                "source": "https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/tree/v3.95.20"
+                "source": "https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/tree/v3.95.23"
             },
             "funding": [
                 {
@@ -759,7 +759,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2026-08-19T16:28:14+00:00"
+            "time": "2026-08-26T19:54:54+00:00"
         },
         {
             "name": "gettext/gettext",
@@ -919,22 +919,22 @@
         },
         {
             "name": "guzzlehttp/guzzle",
-            "version": "7.15.3",
+            "version": "7.15.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/guzzle/guzzle.git",
-                "reference": "ae311b8f045ea93ce7b1c9cdb7cec06c53f944bc"
+                "reference": "ee80339fd9177ba44c49cdb653ff02a4d1106b9a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/guzzle/zipball/ae311b8f045ea93ce7b1c9cdb7cec06c53f944bc",
-                "reference": "ae311b8f045ea93ce7b1c9cdb7cec06c53f944bc",
+                "url": "https://api.github.com/repos/guzzle/guzzle/zipball/ee80339fd9177ba44c49cdb653ff02a4d1106b9a",
+                "reference": "ee80339fd9177ba44c49cdb653ff02a4d1106b9a",
                 "shasum": ""
             },
             "require": {
                 "ext-json": "*",
-                "guzzlehttp/promises": "^2.5.2",
-                "guzzlehttp/psr7": "^2.13",
+                "guzzlehttp/promises": "^2.5.3",
+                "guzzlehttp/psr7": "^2.13.1",
                 "php": "^7.2.5 || ^8.0",
                 "psr/http-client": "^1.0",
                 "symfony/deprecation-contracts": "^2.5 || ^3.0",
@@ -1027,7 +1027,7 @@
             ],
             "support": {
                 "issues": "https://github.com/guzzle/guzzle/issues",
-                "source": "https://github.com/guzzle/guzzle/tree/7.15.3"
+                "source": "https://github.com/guzzle/guzzle/tree/7.15.5"
             },
             "funding": [
                 {
@@ -1043,20 +1043,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-08-05T19:48:21+00:00"
+            "time": "2026-08-24T09:21:06+00:00"
         },
         {
             "name": "guzzlehttp/promises",
-            "version": "2.5.2",
+            "version": "2.5.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/guzzle/promises.git",
-                "reference": "2823687acff28b2dbe67b2508a6b300e2c3fa4ce"
+                "reference": "cde49999552d185d64715fe9c1f77a2aadd2f9f1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/promises/zipball/2823687acff28b2dbe67b2508a6b300e2c3fa4ce",
-                "reference": "2823687acff28b2dbe67b2508a6b300e2c3fa4ce",
+                "url": "https://api.github.com/repos/guzzle/promises/zipball/cde49999552d185d64715fe9c1f77a2aadd2f9f1",
+                "reference": "cde49999552d185d64715fe9c1f77a2aadd2f9f1",
                 "shasum": ""
             },
             "require": {
@@ -1111,7 +1111,7 @@
             ],
             "support": {
                 "issues": "https://github.com/guzzle/promises/issues",
-                "source": "https://github.com/guzzle/promises/tree/2.5.2"
+                "source": "https://github.com/guzzle/promises/tree/2.5.3"
             },
             "funding": [
                 {
@@ -1127,20 +1127,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-08-05T19:30:54+00:00"
+            "time": "2026-08-24T09:11:28+00:00"
         },
         {
             "name": "guzzlehttp/psr7",
-            "version": "2.13.0",
+            "version": "2.13.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/guzzle/psr7.git",
-                "reference": "dad89620b7a6edb60c15858442eb2e408b45d8f4"
+                "reference": "95e7828100de18b4e269fb1703be530082d5166d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/psr7/zipball/dad89620b7a6edb60c15858442eb2e408b45d8f4",
-                "reference": "dad89620b7a6edb60c15858442eb2e408b45d8f4",
+                "url": "https://api.github.com/repos/guzzle/psr7/zipball/95e7828100de18b4e269fb1703be530082d5166d",
+                "reference": "95e7828100de18b4e269fb1703be530082d5166d",
                 "shasum": ""
             },
             "require": {
@@ -1230,7 +1230,7 @@
             ],
             "support": {
                 "issues": "https://github.com/guzzle/psr7/issues",
-                "source": "https://github.com/guzzle/psr7/tree/2.13.0"
+                "source": "https://github.com/guzzle/psr7/tree/2.13.1"
             },
             "funding": [
                 {
@@ -1246,7 +1246,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-07-16T22:23:49+00:00"
+            "time": "2026-08-24T09:13:11+00:00"
         },
         {
             "name": "mck89/peast",
@@ -2786,24 +2786,24 @@
         },
         {
             "name": "sebastian/diff",
-            "version": "7.0.0",
+            "version": "7.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/diff.git",
-                "reference": "7ab1ea946c012266ca32390913653d844ecd085f"
+                "reference": "cd4cabe39f8a4e8ee6818ba99f10a05561ea4ad6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/7ab1ea946c012266ca32390913653d844ecd085f",
-                "reference": "7ab1ea946c012266ca32390913653d844ecd085f",
+                "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/cd4cabe39f8a4e8ee6818ba99f10a05561ea4ad6",
+                "reference": "cd4cabe39f8a4e8ee6818ba99f10a05561ea4ad6",
                 "shasum": ""
             },
             "require": {
                 "php": ">=8.3"
             },
             "require-dev": {
-                "phpunit/phpunit": "^12.0",
-                "symfony/process": "^7.2"
+                "phpunit/phpunit": "^12.5.33",
+                "symfony/process": "^7.4.17"
             },
             "type": "library",
             "extra": {
@@ -2841,15 +2841,27 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/diff/issues",
                 "security": "https://github.com/sebastianbergmann/diff/security/policy",
-                "source": "https://github.com/sebastianbergmann/diff/tree/7.0.0"
+                "source": "https://github.com/sebastianbergmann/diff/tree/7.0.1"
             },
             "funding": [
                 {
                     "url": "https://github.com/sebastianbergmann",
                     "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/sebastian/diff",
+                    "type": "tidelift"
                 }
             ],
-            "time": "2025-02-07T04:55:46+00:00"
+            "time": "2026-08-25T15:35:54+00:00"
         },
         {
             "name": "sirbrillig/phpcs-variable-analysis",
@@ -3158,16 +3170,16 @@
         },
         {
             "name": "symfony/event-dispatcher",
-            "version": "v7.4.15",
+            "version": "v7.4.17",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/event-dispatcher.git",
-                "reference": "336e7f3b9e95aba04f93ea9143920c2186abfbb9"
+                "reference": "d269974ee93c61d03620ffee358355bfdb471d66"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/event-dispatcher/zipball/336e7f3b9e95aba04f93ea9143920c2186abfbb9",
-                "reference": "336e7f3b9e95aba04f93ea9143920c2186abfbb9",
+                "url": "https://api.github.com/repos/symfony/event-dispatcher/zipball/d269974ee93c61d03620ffee358355bfdb471d66",
+                "reference": "d269974ee93c61d03620ffee358355bfdb471d66",
                 "shasum": ""
             },
             "require": {
@@ -3219,7 +3231,7 @@
             "description": "Provides tools that allow your application components to communicate with each other by dispatching events and listening to them",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/event-dispatcher/tree/v7.4.15"
+                "source": "https://github.com/symfony/event-dispatcher/tree/v7.4.17"
             },
             "funding": [
                 {
@@ -3239,7 +3251,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-07-21T15:13:06+00:00"
+            "time": "2026-08-21T17:40:08+00:00"
         },
         {
             "name": "symfony/event-dispatcher-contracts",
@@ -3323,16 +3335,16 @@
         },
         {
             "name": "symfony/filesystem",
-            "version": "v7.4.15",
+            "version": "v7.4.18",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/filesystem.git",
-                "reference": "ff16a16bf87fdf264638b8f6995b3515975e3c79"
+                "reference": "90d412aa5277c6819db39e7605aa46b1019e3232"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/filesystem/zipball/ff16a16bf87fdf264638b8f6995b3515975e3c79",
-                "reference": "ff16a16bf87fdf264638b8f6995b3515975e3c79",
+                "url": "https://api.github.com/repos/symfony/filesystem/zipball/90d412aa5277c6819db39e7605aa46b1019e3232",
+                "reference": "90d412aa5277c6819db39e7605aa46b1019e3232",
                 "shasum": ""
             },
             "require": {
@@ -3369,7 +3381,7 @@
             "description": "Provides basic utilities for the filesystem",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/filesystem/tree/v7.4.15"
+                "source": "https://github.com/symfony/filesystem/tree/v7.4.18"
             },
             "funding": [
                 {
@@ -3389,7 +3401,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-07-22T07:36:05+00:00"
+            "time": "2026-08-23T10:03:40+00:00"
         },
         {
             "name": "symfony/finder",
@@ -3692,16 +3704,16 @@
         },
         {
             "name": "symfony/polyfill-intl-normalizer",
-            "version": "v1.38.0",
+            "version": "v1.42.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-intl-normalizer.git",
-                "reference": "2d446c214bdbe5b71bde5011b060a05fece3ae6b"
+                "reference": "aa20edea75bd9c48cfecc8360922e5a6e5c44502"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-intl-normalizer/zipball/2d446c214bdbe5b71bde5011b060a05fece3ae6b",
-                "reference": "2d446c214bdbe5b71bde5011b060a05fece3ae6b",
+                "url": "https://api.github.com/repos/symfony/polyfill-intl-normalizer/zipball/aa20edea75bd9c48cfecc8360922e5a6e5c44502",
+                "reference": "aa20edea75bd9c48cfecc8360922e5a6e5c44502",
                 "shasum": ""
             },
             "require": {
@@ -3753,7 +3765,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-intl-normalizer/tree/v1.38.0"
+                "source": "https://github.com/symfony/polyfill-intl-normalizer/tree/v1.42.0"
             },
             "funding": [
                 {
@@ -3773,7 +3785,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-05-25T13:48:31+00:00"
+            "time": "2026-08-07T06:33:24+00:00"
         },
         {
             "name": "symfony/polyfill-mbstring",
@@ -4252,16 +4264,16 @@
         },
         {
             "name": "symfony/service-contracts",
-            "version": "v3.7.1",
+            "version": "v3.7.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/service-contracts.git",
-                "reference": "c0a284bab1ed8aa0417e3d69250ab437739563a0"
+                "reference": "15e6a07ec2a2c75ceb1b21dd98105ee8456d2257"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/service-contracts/zipball/c0a284bab1ed8aa0417e3d69250ab437739563a0",
-                "reference": "c0a284bab1ed8aa0417e3d69250ab437739563a0",
+                "url": "https://api.github.com/repos/symfony/service-contracts/zipball/15e6a07ec2a2c75ceb1b21dd98105ee8456d2257",
+                "reference": "15e6a07ec2a2c75ceb1b21dd98105ee8456d2257",
                 "shasum": ""
             },
             "require": {
@@ -4315,7 +4327,7 @@
                 "standards"
             ],
             "support": {
-                "source": "https://github.com/symfony/service-contracts/tree/v3.7.1"
+                "source": "https://github.com/symfony/service-contracts/tree/v3.7.3"
             },
             "funding": [
                 {
@@ -4335,7 +4347,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-06-16T09:55:08+00:00"
+            "time": "2026-07-27T15:39:01+00:00"
         },
         {
             "name": "symfony/stopwatch",

--- a/lib/vendor/composer/installed.php
+++ b/lib/vendor/composer/installed.php
@@ -3,7 +3,7 @@
         'name' => '__root__',
         'pretty_version' => 'dev-master',
         'version' => 'dev-master',
-        'reference' => '2ebf167911b61fb4ee6ef751c607932028a669e7',
+        'reference' => '5d8fe08596e62e35630018fc1c0b95bde91a7788',
         'type' => 'library',
         'install_path' => __DIR__ . '/../../',
         'aliases' => array(),
@@ -13,7 +13,7 @@
         '__root__' => array(
             'pretty_version' => 'dev-master',
             'version' => 'dev-master',
-            'reference' => '2ebf167911b61fb4ee6ef751c607932028a669e7',
+            'reference' => '5d8fe08596e62e35630018fc1c0b95bde91a7788',
             'type' => 'library',
             'install_path' => __DIR__ . '/../../',
             'aliases' => array(),


### PR DESCRIPTION
## Summary
- block single comment REST reads when the parent post is not readable
- apply the same check in the main REST pre-dispatch flow and the legacy REST compatibility path
- reuse a shared helper for extracting the item id and returning a consistent forbidden response

## Testing
- php -l classes/PublishPress/Permissions/REST.php
- php -l classes/PublishPress/Permissions/RESTHelper.php
- php -l classes/PublishPress/Permissions/RESTLegacy.php