### PR TITLE
Harden draft advisory code paths

### DIFF
--- a/classes/PublishPress/Permissions/ErrorNotice.php
+++ b/classes/PublishPress/Permissions/ErrorNotice.php
@@ -184,12 +184,13 @@ class ErrorNotice
                 </p></div>
         <?php endif;
         }
+		$notice_nonce = wp_create_nonce('pp-dismiss-msg');
 		?>
 		<script type="text/javascript">
             jQuery(document).ready( function($) {
                 $('a.presspermit-dismiss-notice').on('click', function(e) {
                     $(this).closest('div').slideUp();
-                    jQuery.post(ajaxurl, {action:"pp_dismiss_msg", msg_id:$(this).attr('id'), cookie: encodeURIComponent(document.cookie)});
+                    jQuery.post(ajaxurl, {action:"pp_dismiss_msg", msg_id:$(this).attr('id'), cookie: encodeURIComponent(document.cookie), _ajax_nonce:"<?php echo esc_js($notice_nonce); ?>"});
                 });
             });
 		</script>

--- a/classes/PublishPress/Permissions/UI/AgentPermissions.php
+++ b/classes/PublishPress/Permissions/UI/AgentPermissions.php
@@ -14,11 +14,6 @@ class AgentPermissions
         $pp_admin = $pp->admin();
         $pp_groups = $pp->groups();
 
-        if (!PWP::empty_REQUEST('pp_fix_child_exceptions')) {
-            require_once(PRESSPERMIT_CLASSPATH . '/DB/PermissionsUpdate.php');
-            \PublishPress\Permissions\DB\PermissionsUpdate::ensureExceptionPropagation();
-        }
-
         require_once(PRESSPERMIT_CLASSPATH . '/UI/AgentPermissionsUI.php');
 
         if (!$agent_type = PWP::REQUEST_key('agent_type')) {
@@ -54,6 +49,17 @@ class AgentPermissions
             if (!$agent) {
                 wp_die(esc_html__('Invalid group ID.', 'press-permit-core'));
             }
+        }
+
+        if (PWP::is_POST('pp_fix_child_exceptions')) {
+            check_admin_referer('pp-fix-child-exceptions');
+
+            if (!current_user_can('pp_manage_permissions')) {
+                wp_die(esc_html__('You are not permitted to do that.', 'press-permit-core'));
+            }
+
+            require_once(PRESSPERMIT_CLASSPATH . '/DB/PermissionsUpdate.php');
+            \PublishPress\Permissions\DB\PermissionsUpdate::ensureExceptionPropagation();
         }
 
         if ($metagroup_type) {  // metagroups cannot have name/description manually edited

--- a/classes/PublishPress/Permissions/UI/AgentPermissionsAjax.php
+++ b/classes/PublishPress/Permissions/UI/AgentPermissionsAjax.php
@@ -369,7 +369,7 @@ class AgentPermissionsAjax
         $pp_admin = presspermit()->admin();
 
         global $wpdb;
-        $add_ids_csv = implode("','", array_map('intval', $ass_ids));
+        $ass_ids_csv = implode("','", array_map('intval', $ass_ids));
 
         // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
         $results = $wpdb->get_results(

--- a/classes/PublishPress/Permissions/UI/AgentPermissionsAjax.php
+++ b/classes/PublishPress/Permissions/UI/AgentPermissionsAjax.php
@@ -366,6 +366,8 @@ class AgentPermissionsAjax
             return $ass_ids;
         }
 
+        $pp_admin = presspermit()->admin();
+
         global $wpdb;
         $add_ids_csv = implode("','", array_map('intval', $ass_ids));
 

--- a/classes/PublishPress/Permissions/UI/AgentPermissionsUI.php
+++ b/classes/PublishPress/Permissions/UI/AgentPermissionsUI.php
@@ -1610,8 +1610,7 @@ class AgentPermissionsUI
                                 }
 
                                 if (defined('WP_DEBUG') || defined('PRESSPERMIT_DEBUG')) {
-
-                                    $fix_child_url = add_query_arg('pp_fix_child_exceptions', '1', esc_url_raw($_SERVER['REQUEST_URI']));
+                                    $fix_child_url = remove_query_arg(['pp_fix_child_exceptions', '_wpnonce'], esc_url_raw($_SERVER['REQUEST_URI']));
 
                                     if (PWP::empty_REQUEST('show_propagated')) {
                                         echo '&nbsp;&nbsp;&bull;';
@@ -1623,9 +1622,12 @@ class AgentPermissionsUI
                                         '<span data-toggle="tooltip" data-placement="top">%1$s<span class="tooltip-text"><span style="white-space: normal;">%2$s</span><i></i></span><i class="dashicons dashicons-info-outline" style="font-size: 18px;width: 16px;height: 16px;padding-top:2px"></i></span>',
                                         sprintf(
                                             esc_html__(' %1$sFix Sub-%2$s Permissions%3$s', 'press-permit-core'),
-                                        "&nbsp;<a href='" . esc_url($fix_child_url) . "' class='btn btn-link' style='padding-right:4px'>",
+	                                        '<form action="' . esc_url($fix_child_url) . '" method="post" style="display:inline">'
+	                                            . wp_nonce_field('pp-fix-child-exceptions', '_wpnonce', true, false)
+	                                            . '<input type="hidden" name="pp_fix_child_exceptions" value="1" />'
+	                                            . '<button type="submit" class="btn btn-link" style="padding-right:4px;background:none;border:0">',
                                             esc_html($via_type_obj->labels->singular_name),
-                                            '</a>'
+                                            '</button></form>'
                                         ),
                                         esc_html($fix_sub_tooltip)
                                     );

--- a/classes/PublishPress/Permissions/UI/Handlers/AgentEdit.php
+++ b/classes/PublishPress/Permissions/UI/Handlers/AgentEdit.php
@@ -185,6 +185,12 @@ class AgentEdit
                     foreach ($_POST['pp_add_role'] as $add_role) {
                         $attrib_cond = (!empty($add_role['attrib_cond'])) ? ':' . PWP::sanitizeEntry(sanitize_text_field($add_role['attrib_cond'])) : '';
                         $role = (isset($add_role['role'])) ? PWP::sanitizeEntry(sanitize_text_field($add_role['role'])) : '';
+                        $role_type = (isset($add_role['type'])) ? sanitize_key($add_role['type']) : '';
+                        $base_role_name = strtok($role, ':');
+
+                        if (!$role || !$role_type || !$base_role_name || !presspermit()->admin()->userCanAdminRole($base_role_name, $role_type)) {
+                            continue;
+                        }
 
                         presspermit()->assignRoles(["{$role}{$attrib_cond}" => [$_agent_id => true]], $agent_type);
                     }

--- a/classes/PublishPress/Permissions/UI/ItemsMetabox.php
+++ b/classes/PublishPress/Permissions/UI/ItemsMetabox.php
@@ -783,6 +783,10 @@ class ItemsMetabox extends \Walker_Nav_Menu
 
         if (preg_match('/quick-search-(posttype|taxonomy)-([a-zA-Z_-]*\b)/', $type, $matches)) {
             if ('posttype' == $matches[1] && $type_obj = get_post_type_object($matches[2])) {
+                if (!presspermit()->admin()->canSetAnyPostPermissions($matches[2])) {
+                    wp_die(-1);
+                }
+
                 $args['hierarchical'] = $type_obj->hierarchical;
 
                 $status = ('attachment' == $matches[2]) ? 'inherit' : '';
@@ -816,6 +820,10 @@ class ItemsMetabox extends \Walker_Nav_Menu
                     echo walk_nav_menu_tree(array_map([__CLASS__, 'setup_nav_menu_item'], [get_post($var_by_ref)]), 0, (object)$args);
                 }
             } elseif ('taxonomy' == $matches[1]) {
+                if (!presspermit()->admin()->canSetAnyTermPermissions('', $matches[2])) {
+                    wp_die(-1);
+                }
+
                 $terms = get_terms($matches[2], [
                     'name__like' => $query,
                     'hide_empty' => false,

--- a/classes/PublishPress/PermissionsHooksAdmin.php
+++ b/classes/PublishPress/PermissionsHooksAdmin.php
@@ -566,12 +566,12 @@ class PermissionsHooksAdmin
 
     public function dashboardDismissMsg()
     {
+        check_ajax_referer('pp-dismiss-msg');
+
         $dismissals = get_option('presspermit_dismissals');
         if (!is_array($dismissals)) {
             $dismissals = [];
         }
-
-        // phpcs Note: No need for nonce verification on the notice dismissal
 
         // phpcs:ignore WordPress.Security.NonceVerification.Recommended
         $msg_id = (isset($_REQUEST['msg_id'])) ? sanitize_key($_REQUEST['msg_id']) : 'post_blockage_priority';

--- a/classes/PublishPress/PermissionsHooksAdmin.php
+++ b/classes/PublishPress/PermissionsHooksAdmin.php
@@ -111,6 +111,8 @@ class PermissionsHooksAdmin
             }
     
             if (!PWP::empty_REQUEST('presspermit_refresh_updates')) {
+                check_admin_referer('presspermit-refresh-updates');
+
                 delete_site_transient('update_plugins');
                 delete_option('_site_transient_update_plugins');
                 wp_update_plugins();
@@ -567,6 +569,10 @@ class PermissionsHooksAdmin
     public function dashboardDismissMsg()
     {
         check_ajax_referer('pp-dismiss-msg');
+
+        if (!current_user_can('pp_manage_settings')) {
+            wp_die(-1);
+        }
 
         $dismissals = get_option('presspermit_dismissals');
         if (!is_array($dismissals)) {


### PR DESCRIPTION
## Summary
- restrict REST operation overrides to supported post operations
- add authorization and nonce checks to affected admin and AJAX permission flows
- require POST plus nonce for the child-exception repair action
- fix role-assignment authorization and assignment filtering checks

## Testing
- php -l classes/PublishPress/Permissions/REST.php
- php -l classes/PublishPress/Permissions/UI/ItemsMetabox.php
- php -l classes/PublishPress/Permissions/UI/Handlers/AgentEdit.php
- php -l classes/PublishPress/Permissions/UI/AgentPermissions.php
- php -l classes/PublishPress/Permissions/UI/AgentPermissionsAjax.php
- php -l classes/PublishPress/PermissionsHooksAdmin.php
- php -l classes/PublishPress/Permissions/ErrorNotice.php
- php -l classes/PublishPress/Permissions/UI/AgentPermissionsUI.php