### PR TITLE
Keep Editing Permissions active and hidden for feature tab

### DIFF
--- a/classes/PublishPress/Permissions.php
+++ b/classes/PublishPress/Permissions.php
@@ -383,6 +383,7 @@ class Permissions
     public function loadModules()
     {
         $inactive_modules = (array) $this->getOption('deactivated_modules');
+        $inactive_modules = array_diff_key($inactive_modules, array_fill_keys($this->getRequiredModules(), true));
 
         $dir = PRESSPERMIT_ABSPATH . '/modules/';
 
@@ -419,6 +420,11 @@ class Permissions
         return $modules;
     }
 
+    public function getRequiredModules()
+    {
+        return ['presspermit-collaboration'];
+    }
+
     public function moduleExists($slug)
     {
         return in_array($slug, $this->getAvailableModules());
@@ -427,6 +433,7 @@ class Permissions
     public function getDeactivatedModules()
     {
         $modules = (array) $this->getOption('deactivated_modules');
+        $modules = array_diff_key($modules, array_fill_keys($this->getRequiredModules(), true));
         return array_intersect_key($modules, array_fill_keys($this->getAvailableModules(), true));
     }
 

--- a/classes/PublishPress/Permissions/PluginUpdated.php
+++ b/classes/PublishPress/Permissions/PluginUpdated.php
@@ -170,6 +170,8 @@ class PluginUpdated
             $new_deactivations = array_diff($new_deactivations, $args['activate']);
         }
 
+        $new_deactivations = array_diff($new_deactivations, presspermit()->getRequiredModules());
+
         if (!is_array($deactivated)) {
             $deactivated = [];
         }
@@ -182,6 +184,8 @@ class PluginUpdated
             $deactivated, 
             array_fill_keys($new_deactivations, (object)[])
         );
+
+        $deactivated = array_diff_key($deactivated, array_fill_keys(presspermit()->getRequiredModules(), true));
         
         update_option('presspermit_deactivated_modules', $deactivated);
     }

--- a/classes/PublishPress/Permissions/UI/Handlers/Settings.php
+++ b/classes/PublishPress/Permissions/UI/Handlers/Settings.php
@@ -168,6 +168,8 @@ class Settings
         }
 
         // =============== Module Activation ================
+        $required_modules = array_fill_keys($pp->getRequiredModules(), true);
+
         if (!$_deactivated = $pp->getOption('deactivated_modules')) {
             $_deactivated = [];
         }
@@ -192,6 +194,8 @@ class Settings
             );
         }
 
+        $deactivated = array_diff_key($deactivated, $required_modules);
+
         // remove deactivations (checked in Inactive list)
         if (!empty($_POST['presspermit_deactivated_modules'])) {
             $deactivated = array_diff_key(
@@ -199,6 +203,8 @@ class Settings
                 array_map('sanitize_key', (array) $_POST['presspermit_deactivated_modules'])
             );
         }
+
+        $deactivated = array_diff_key($deactivated, $required_modules);
 
         if ($_deactivated !== $deactivated) {
             foreach (array_diff_key($deactivated, $_deactivated) as $module_name => $module) {

--- a/classes/PublishPress/Permissions/UI/SettingsTabModules.php
+++ b/classes/PublishPress/Permissions/UI/SettingsTabModules.php
@@ -71,6 +71,7 @@ class SettingsTabModules
                         $ext_info = $pp->admin()->getModuleInfo();
                         $pp_modules = $pp->getActiveModules();
                         $inactive = $pp->getDeactivatedModules();
+                        $required_modules = array_fill_keys($pp->getRequiredModules(), true);
                         $skipped_modules = $pp->getSkippedModules();
                         $active_module_plugin_slugs = [];
                         // Combine active and inactive modules into single array
@@ -90,6 +91,8 @@ class SettingsTabModules
                                 // Skip modules that are in the skipped list
                                 if (in_array($slug, $skipped_slugs)) continue;
 
+                                if (isset($required_modules[$plugin_info->plugin_slug])) continue;
+
                                 $active_module_plugin_slugs[] = $plugin_info->plugin_slug;
                                 $all_modules[] = [
                                     'slug' => $slug,
@@ -107,6 +110,8 @@ class SettingsTabModules
                                 
                                 // Skip modules that are in the skipped list
                                 if (in_array($slug, $skipped_slugs)) continue;
+
+                                if (isset($required_modules[$plugin_slug])) continue;
 
                                 $all_modules[] = [
                                     'slug' => $slug,


### PR DESCRIPTION
## Summary
- make `presspermit-collaboration` a required module so it cannot be deactivated
- strip the module from any stored deactivation state during load, settings saves, and default migration updates
- hide the Editing Permissions card from the Features screen since it is no longer user-toggleable

## Testing
- php -l classes/PublishPress/Permissions.php
- php -l classes/PublishPress/Permissions/PluginUpdated.php
- php -l classes/PublishPress/Permissions/UI/Handlers/Settings.php
- php -l classes/PublishPress/Permissions/UI/SettingsTabModules.php

Supersedes #2472 with the complete implementation.