### PR TITLE
readme: spend the five tag slots on winnable phrases

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -1,7 +1,7 @@
 === PublishPress Permissions: Control User Access for Posts, Pages, Categories, Tags ===
 
 Contributors: publishpress, kevinB, stevejburge, andergmartins
-Tags: permissions, access, restrict, privacy, capabilities
+Tags: permissions, content permissions, access control, user access, restrict
 Requires at least: 5.5
 Tested up to: 7.1
 Requires PHP: 7.2.5


### PR DESCRIPTION
`permissions` already appears **109 times** in this readme and the plugin is **#5**. The bare term is not winnable by writing more of it:

| | | |
|---|---|---|
| 1 | google-site-kit | 5,000,000 |
| 2 | **capability-manager-enhanced** | 100,000 — *PublishPress Capabilities* |
| 3 | **advanced-gutenberg** | 20,000 — *PublishPress Blocks* |
| 4 | members | 300,000 |
| 5 | **press-permit-core** | 10,000 — *this plugin* |

**We are being outranked for "permissions" by two of our own plugins**, which no edit in this repo fixes.

So the tags now point at phrases this plugin should own instead of repeating the one it cannot:

`Tags: permissions, content permissions, access control, user access, restrict`

| new tag | current position |
|---|---|
| content permissions | #8 of 4,075 |
| user access | #12 of 10,000 (and it matches the title) |
| access control | #17 of 6,356 |

Dropped `privacy` (generic, pulls unrelated competition) and `capabilities` (our sibling plugin term, where Capabilities is already #1 and needs no help). `restrict content` was measured and rejected — **#93 of 2,211**.

Title and body untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)