### PR TITLE
Add CodeQL workflow

### DIFF
--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -1,0 +1,7 @@
+name: PublishPress Permissions CodeQL config
+
+paths-ignore:
+  - "vendor/**"
+  - "node_modules/**"
+  - "dev-workspace/**"
+  - "**/*.min.js"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,45 @@
+name: CodeQL
+
+on:
+  push:
+    branches:
+      - development
+  pull_request:
+    branches:
+      - development
+  schedule:
+    - cron: "41 5 * * 5"
+
+permissions:
+  contents: read
+  security-events: write
+
+jobs:
+  analyze:
+    name: Analyze (${{ matrix.language }})
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - language: actions
+            build-mode: none
+          - language: javascript-typescript
+            build-mode: none
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v4
+        with:
+          languages: ${{ matrix.language }}
+          build-mode: ${{ matrix.build-mode }}
+          config-file: ./.github/codeql/codeql-config.yml
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v4
+        with:
+          category: "/language:${{ matrix.language }}"


### PR DESCRIPTION
## Summary
- Add a CodeQL workflow based on publishpress-planner PR #2045
- Scan GitHub Actions and JavaScript/TypeScript on pushes and PRs to development
- Ignore dependency and generated paths in the CodeQL config

## Testing
- Parsed the workflow and config YAML with python3