### PR TITLE
Update teaser text descriptions

### DIFF
--- a/modules/presspermit-teaser/classes/Permissions/Teaser/UI/PostsTeaser.php
+++ b/modules/presspermit-teaser/classes/Permissions/Teaser/UI/PostsTeaser.php
@@ -36,7 +36,7 @@ class PostsTeaser
         $new = [
             'teaser_type' => esc_html__('Teaser Type', 'press-permit-core'),
             'coverage' => esc_html__('Coverage', 'press-permit-core'),
-            'teaser_text' => esc_html__('Teaser Text', 'press-permit-core'),
+            'teaser_text' => esc_html__('No Teaser Test', 'press-permit-core'),
             'read_more_notice' => esc_html__('Read More Notice', 'press-permit-core'),
             'redirect' => esc_html__('Redirect', 'press-permit-core'),
             'options' => esc_html__('Options', 'press-permit-core'),

--- a/modules/presspermit-teaser/classes/Permissions/Teaser/UI/TeaserProgressiveUI.php
+++ b/modules/presspermit-teaser/classes/Permissions/Teaser/UI/TeaserProgressiveUI.php
@@ -1399,7 +1399,7 @@ class TeaserProgressiveUI {
                 <thead>
                     <tr>
                         <th>
-                            <strong><?php esc_html_e('Teaser Message Style Customization', 'press-permit-core'); ?></strong>
+                            <strong><?php esc_html_e('Customize the Message for Blocked Users', 'press-permit-core'); ?></strong>
                             <?php $this->generateTooltip(esc_html__('Customize the appearance of teaser message displayed to blocked users.', 'press-permit-core')); ?>
                         </th>
                     </tr>


### PR DESCRIPTION
## Summary
- Rename the Teaser Text section caption to match the issue request
- Rename the teaser message style heading to clarify it customizes blocked-user messages

Fixes #2528

## Tests
- php -l modules/presspermit-teaser/classes/Permissions/Teaser/UI/PostsTeaser.php
- php -l modules/presspermit-teaser/classes/Permissions/Teaser/UI/TeaserProgressiveUI.php
- git diff --check