### PR TITLE
Allow shortcodes in teaser messages

### DIFF
--- a/modules/presspermit-teaser/classes/Permissions/Teaser/PostsTeaser.php
+++ b/modules/presspermit-teaser/classes/Permissions/Teaser/PostsTeaser.php
@@ -436,6 +436,8 @@ class PostsTeaser
                 } else {
                     $msg = str_replace('[login_form]', '', $msg);
                 }
+
+                $msg = self::renderTeaserMessage($msg);
             }
 
             // Apply styled notice wrapper for content replacement on frontend (not in admin or feeds)
@@ -822,6 +824,7 @@ class PostsTeaser
     private static function wrapTeaserNotice($message, $post_type = '')
     {
         $pp = presspermit();
+        $message = self::renderTeaserMessage($message);
         
         // Check if custom styling mode is enabled for this post type
         $style_mode = $pp->getTypeOption('teaser_notice_style_mode', $post_type);
@@ -866,5 +869,10 @@ class PostsTeaser
         );
         
         return '<div class="pp-teaser-notice" style="' . $inline_style . '">' . $message . '</div>';
+    }
+
+    public static function renderTeaserMessage($message)
+    {
+        return do_shortcode(shortcode_unautop((string) $message));
     }
 }

--- a/modules/presspermit-teaser/classes/Permissions/Teaser/ReadMoreHandler.php
+++ b/modules/presspermit-teaser/classes/Permissions/Teaser/ReadMoreHandler.php
@@ -176,7 +176,7 @@ class ReadMoreHandler
             
             $info_message = sprintf(
                 '<p class="pp-teaser-login-notice" style="padding: 15px; background: #f0f6fc; border-left: 4px solid #0073aa; margin: 15px 0; font-size: 14px; line-height: 1.6;">%s</p>',
-                esc_html($notice_text)
+                PostsTeaser::renderTeaserMessage($notice_text)
             );
             
             $info_message = apply_filters('presspermit_read_more_login_notice', $info_message, $post);


### PR DESCRIPTION
## Summary
- Run configured teaser content messages through shortcode processing
- Run teaser notice messages through the same renderer before wrapping
- Preserve existing special [login_form] behavior

Fixes #2524

## Tests
- php -l modules/presspermit-teaser/classes/Permissions/Teaser/PostsTeaser.php
- php -l modules/presspermit-teaser/classes/Permissions/Teaser/ReadMoreHandler.php
- git diff --check