### PR TITLE
Prevent teaser message overflow

### DIFF
--- a/modules/presspermit-teaser/classes/Permissions/Teaser/PostsTeaser.php
+++ b/modules/presspermit-teaser/classes/Permissions/Teaser/PostsTeaser.php
@@ -828,7 +828,7 @@ class PostsTeaser
         
         // If not set to 'custom', return simple default notice
         if ($style_mode !== 'custom') {
-            return '<div class="pp-teaser-notice" style="padding: 15px; background: #f0f6fc; border-left: 4px solid #0073aa; margin: 15px 0; font-size: 14px; line-height: 1.6;">' . $message . '</div>';
+            return '<div class="pp-teaser-notice" style="box-sizing: border-box; max-width: 100%; overflow-wrap: anywhere; word-break: break-word; padding: 15px; background: #f0f6fc; border-left: 4px solid #0073aa; margin: 15px 0; font-size: 14px; line-height: 1.6;">' . $message . '</div>';
         }
         
         // Get custom style settings with defaults (per-post-type)
@@ -856,7 +856,7 @@ class PostsTeaser
         
         // Build complete inline style
         $inline_style = sprintf(
-            'padding: %spx; background: %s; color: %s; %s margin: 15px 0; font-size: %spx; line-height: 1.6; border-radius: %spx;',
+            'box-sizing: border-box; max-width: 100%%; overflow-wrap: anywhere; word-break: break-word; padding: %spx; background: %s; color: %s; %s margin: 15px 0; font-size: %spx; line-height: 1.6; border-radius: %spx;',
             esc_attr($padding),
             esc_attr($bg_color),
             esc_attr($text_color),

--- a/modules/presspermit-teaser/classes/Permissions/Teaser/ReadMoreHandler.php
+++ b/modules/presspermit-teaser/classes/Permissions/Teaser/ReadMoreHandler.php
@@ -175,7 +175,7 @@ class ReadMoreHandler
             }
             
             $info_message = sprintf(
-                '<p class="pp-teaser-login-notice" style="padding: 15px; background: #f0f6fc; border-left: 4px solid #0073aa; margin: 15px 0; font-size: 14px; line-height: 1.6;">%s</p>',
+                '<p class="pp-teaser-login-notice" style="box-sizing: border-box; max-width: 100%; overflow-wrap: anywhere; word-break: break-word; padding: 15px; background: #f0f6fc; border-left: 4px solid #0073aa; margin: 15px 0; font-size: 14px; line-height: 1.6;">%s</p>',
                 esc_html($notice_text)
             );
             

--- a/modules/presspermit-teaser/common/css/settings.css
+++ b/modules/presspermit-teaser/common/css/settings.css
@@ -1034,6 +1034,8 @@ tr.pp-main-row:hover td:not(.pp-expand) {
     color: #3c434a;
     font-size: 16px;
     line-height: 1.7;
+    overflow-wrap: anywhere;
+    word-break: break-word;
 }
 
 .pp-teaser-preview-body {


### PR DESCRIPTION
## Summary
- Add wrapping constraints to teaser notice wrappers
- Add wrapping to the admin teaser preview content
- Prevent long unbroken teaser text from forcing horizontal page overflow

Fixes #2523

## Tests
- php -l modules/presspermit-teaser/classes/Permissions/Teaser/PostsTeaser.php
- php -l modules/presspermit-teaser/classes/Permissions/Teaser/ReadMoreHandler.php
- git diff --check